### PR TITLE
Install systemd unit from pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include apidoc.json LICENSE
 graft share
+include temboard-agent.service

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,13 @@ setup(
     url='http://temboard.io/',
     description='Administration & monitoring PostgreSQL agent.',
     long_description=open('README.rst').read(),
-    data_files=[('share/temboard-agent/', [
-        'share/temboard-agent.conf.sample',
-        'share/temboard-agent_CHANGEME.pem',
-        'share/temboard-agent_CHANGEME.key',
-        'share/temboard-agent_ca_certs_CHANGEME.pem',
-        'share/temboard-agent.logrotate'
-    ])])
+    data_files=[
+        ('share/temboard-agent/', [
+            'share/temboard-agent.conf.sample',
+            'share/temboard-agent_CHANGEME.pem',
+            'share/temboard-agent_CHANGEME.key',
+            'share/temboard-agent_ca_certs_CHANGEME.pem',
+            'share/temboard-agent.logrotate'
+        ]),
+        ('lib/systemd/system', ['temboard-agent.service']),
+    ])

--- a/temboard-agent.service
+++ b/temboard-agent.service
@@ -1,0 +1,27 @@
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the
+# best way is to create a file "/etc/systemd/system/temboard-agent.service",
+# containing
+#	.include /lib/systemd/system/temboard-agent.service
+#	...make your changes here...
+# For more info about custom unit files, see
+# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
+
+[Unit]
+Description=temBoard agent for PostgreSQL
+After=network.target syslog.target
+
+[Service]
+Type=forking
+
+User=postgres
+Group=postgres
+
+PIDFile=/var/run/postgresql/temboard-agent.pid
+
+ExecStart=/usr/bin/temboard-agent -c /etc/temboard-agent/temboard-agent.conf -d -p /var/run/postgresql/temboard-agent.pid
+ExecStop=/bin/kill -TERM $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since it's cross distro, install it anyway from pip, debian, rpm, etc.

Test it with at least jessie:

``` console
$ python setup.py sdist
$ sudo systemctl status temboard-agend
$ sudo pip install dist/temboad-agent....tar.gz
$ sudo systemctl daemon-reload
$ sudo systemctl status temboard-agend
```

Before installing, you have:


``` console
$ sudo systemctl status temboard-agent
● temboard-agent.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
```

After installation, you should get

```
 ● temboard-agent.service - temBoard agent for PostgreSQL
   Loaded: loaded (/usr/local/lib/systemd/system/temboard-agent.service; disabled)
   Active: inactive (dead)
```

This is enough to tell us that `temboard-agent.service` is properly loaded.
