### PR TITLE
Merge arguments and file in configuration

### DIFF
--- a/temboard-agent-adduser
+++ b/temboard-agent-adduser
@@ -3,14 +3,27 @@
 from __future__ import unicode_literals
 from sys import stdout, stderr
 from getpass import getpass
+from optparse import OptionParser
 
 from temboardagent.usermgmt import hash_password
-from temboardagent.options import CLIOptions
 from temboardagent.errors import ConfigurationError, HTTPError
 from temboardagent.usermgmt import get_user
 from temboardagent.configuration import Configuration
 from temboardagent.types import T_PASSWORD, T_USERNAME
 from temboardagent.tools import validate_parameters
+
+
+class CLIOptions(OptionParser):
+    """
+    Command line interface options parser.
+    """
+    def __init__(self, *args, **kwargs):
+        OptionParser.__init__(self, *args, **kwargs)
+        self.add_option("-c",
+                        "--config",
+                        dest="configfile",
+                        help="Configuration file. Default: %default",
+                        default="/etc/temboard-agent/temboard-agent.conf")
 
 
 def ask_password():

--- a/temboardagent/cli.py
+++ b/temboardagent/cli.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def define_common_arguments(parser):
     parser.add_argument(
         '-c', '--config',
-        action='store', dest='configfile',
+        action='store', dest='temboard_configfile',
         default='/etc/temboard-agent/temboard-agent.conf',
         help="Configuration file. Default: %(default)s",
     )

--- a/temboardagent/register.py
+++ b/temboardagent/register.py
@@ -99,7 +99,7 @@ def main(argv, environ):
     args = parser.parse_args(argv)
 
     # Loading agent configuration file.
-    config = LazyConfiguration(args.configfile)
+    config = LazyConfiguration(args.temboard_configfile)
 
     # Load configuration from the configuration file.
     try:

--- a/temboardagent/utils.py
+++ b/temboardagent/utils.py
@@ -1,0 +1,45 @@
+from UserDict import UserDict
+
+
+_UNDEFINED = object()
+
+
+def dict_factory(iterable=_UNDEFINED, **kw):
+    # a dict factory that do not copy.
+    if iterable is _UNDEFINED:
+        return kw
+    elif isinstance(iterable, dict):
+        return iterable
+    else:
+        return dict(iterable, **kw)
+
+
+class DotDict(UserDict):
+    # A wrapper around dict that allows read and write through dot style
+    # accessors.
+
+    def __init__(self, *a, **kw):
+        self.__dict__['data'] = dict_factory(*a, **kw)
+
+    def __getattr__(self, name):
+        try:
+            value = self[name]
+            # Lazy recursion of DotDict
+            if isinstance(value, dict):
+                self[name] = value = DotDict(value)
+            return value
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if hasattr(value, 'items'):
+            value = DotDict(value)
+        self[name] = value
+
+    def setdefault(self, name, default):
+        if hasattr(default, 'items'):
+            default = DotDict(default)
+        return UserDict.setdefault(self, name, default)
+
+    def __iter__(self):
+        return iter(self.keys())

--- a/test/legacy/test/temboard.py
+++ b/test/legacy/test/temboard.py
@@ -172,9 +172,8 @@ def agent_start(pid_file, conf_file, python="python"):
             pid_file
             )
 
-    exec_command(cmd, comm=False, shell=True)
-    # Let's sleep a bit
-    time.sleep(1)
+    retcode, stdout, stderr = exec_command(cmd, comm=True, shell=True)
+    assert retcode == 0, stderr
 
 
 def agent_stop(pid_file):

--- a/test/unit/test_agent_main.py
+++ b/test/unit/test_agent_main.py
@@ -9,11 +9,9 @@ def test_help(mocker):
 
 
 def test_big_main(mocker):
-    mocker.patch('temboardagent.agent.Configuration')
+    mocker.patch('temboardagent.agent.load_configuration')
     mocker.patch('temboardagent.agent.daemonize')
-    mocker.patch('temboardagent.agent.logging.config.dictConfig')
     mocker.patch('temboardagent.agent.httpd_run')
-    mocker.patch('temboardagent.agent.load_plugins_configurations')
     mocker.patch('temboardagent.agent.Process')
     mocker.patch('temboardagent.agent.purge_queue_dir')
 

--- a/test/unit/test_agent_main.py
+++ b/test/unit/test_agent_main.py
@@ -1,6 +1,13 @@
 import pytest
 
 
+def test_help(mocker):
+    from temboardagent.agent import main
+
+    with pytest.raises(SystemExit):
+        main(argv=['--help'])
+
+
 def test_big_main(mocker):
     mocker.patch('temboardagent.agent.Configuration')
     mocker.patch('temboardagent.agent.daemonize')

--- a/test/unit/test_configuration.py
+++ b/test/unit/test_configuration.py
@@ -1,4 +1,65 @@
-def test_import():
-    # Just a first test to setup unit tests
-    import temboardagent.configuration as _
-    _
+import pytest
+
+
+def test_spec_and_value():
+    from temboardagent.configuration import OptionSpec, Value
+
+    spec = OptionSpec(section='temboard', name='verbose', default=False)
+    assert repr(spec)
+
+    value = Value('temboard_verbose', True, origin='test')
+    assert repr(value)
+
+    assert value.name in {spec}
+
+
+def test_load(mocker):
+    mocker.patch('temboardagent.configuration.Configuration')
+    mocker.patch('temboardagent.configuration.MergedConfiguration.load_file')
+    mocker.patch('temboardagent.configuration.load_plugins_configurations')
+
+    from argparse import Namespace
+    from temboardagent.configuration import OptionSpec, load_configuration
+
+    specs = [
+        OptionSpec(section='temboard', name='verbose', default=False),
+    ]
+    args = Namespace()
+    config = load_configuration(specs=specs, args=args)
+
+    assert config.temboard.verbose is False
+    assert config.temboard.configfile.startswith('/etc/temboard-agent/')
+    assert config.loaded is True
+
+    args = Namespace(unkown=True)
+    with pytest.raises(Exception):
+        load_configuration(specs=specs, args=args)
+
+
+def test_legacy(mocker):
+    from temboardagent.configuration import MergedConfiguration, configparser
+
+    configparser = configparser.RawConfigParser()
+    configparser.temboard = {'port': 8080}
+    configparser.configfile = 'configfile'
+    configparser.confdir = 'confdir'
+    config = MergedConfiguration()
+
+    config.load_file(configparser)
+
+    assert 8080 == config.temboard.port
+    assert 'configfile' == config.configfile
+    assert 'confdir' == config.confdir
+
+
+def test_logging():
+    from temboardagent.configuration import generate_logging_config, DotDict
+
+    config = DotDict(dict(logging=dict(
+        destination='pouet',
+        facility='local0',
+        method='stderr',
+        level='DEBUG',
+    )))
+
+    generate_logging_config(config)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,48 @@
+def test_dict_factory():
+    from temboardagent.utils import dict_factory
+
+    my = dict_factory()
+    assert isinstance(my, dict)
+    assert 0 == len(my)
+
+    my = dict_factory(dict(a=True))
+    assert isinstance(my, dict)
+    assert 1 == len(my)
+    assert my['a'] is True
+
+    my = dict_factory([('a', True)])
+    assert isinstance(my, dict)
+    assert 1 == len(my)
+    assert my['a'] is True
+
+    original = dict(a=True)
+    my = dict_factory(original)
+    original['a'] = False
+    assert my['a'] is False
+
+
+def test_dotdict():
+    from temboardagent.utils import DotDict
+
+    my = DotDict(dict(a=1, b=dict(c=2)))
+
+    assert 1 == my.a
+    assert 1 == my['a']
+    assert 2 == my.b.c
+    assert 2 == my['b'].c
+
+    keys = list(iter(my))
+    assert 'a' in keys
+    assert 'b' in keys
+
+    my.a = 3
+    my.b.c = 4
+
+    assert 3 == my.a
+    assert 4 == my['b']['c']
+
+    my['a'] = 5
+    assert 5 == my.a
+
+    d = my.setdefault('d', dict(e=True))
+    assert d.e is True


### PR DESCRIPTION
This PR begins the big review of configuration management for #44 

The first steps are:

- Distinguish configuration from `ConfigParser`.
- Push arguments from CLI in configuration.
- Push defaults in configuration.
- Implement base API to define option and basic option marshalling
- Keep compatibility for the code base to avoid big rename everywhere.