### PR TITLE
Fix error on reload

### DIFF
--- a/temboardagent/configuration.py
+++ b/temboardagent/configuration.py
@@ -258,7 +258,7 @@ class MergedConfiguration(DotDict):
         old_plugins = self.temboard.plugins
 
         try:
-            self.load_file(self, self.temboard.configfile)
+            self.load_file(self.temboard.configfile)
         except Exception as e:
             raise ConfigurationError(str(e))
 


### PR DESCRIPTION
```
2017-11-08 22:29:15,107 temboard-agent[20206]: [httpd] INFO: SIGHUP signal caught, trying to reload configuration.
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR: load_file() takes exactly 2 arguments (3 given)
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR: Traceback (most recent call last):
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR:   File "/usr/lib/python2.7/site-packages/temboardagent/httpd.py", line 227, in httpd_run
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR:     config = config.reload()
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR:   File "/usr/lib/python2.7/site-packages/temboardagent/configuration.py", line 263, in reload
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR:     raise ConfigurationError(str(e))
2017-11-08 22:29:15,108 temboard-agent[20206]: [httpd] ERROR: ConfigurationError: load_file() takes exactly 2 arguments (3 given)
2017-11-08 22:29:15,109 temboard-agent[20206]: [httpd] INFO: Keeping previous configuration.
```