### PR TITLE
Don't send args default to configuration

### DIFF
--- a/temboardagent/scripts/register.py
+++ b/temboardagent/scripts/register.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, SUPPRESS as UNDEFINED_ARGUMENT
 import os
 from sys import stdout, stderr
 from getpass import getpass
@@ -96,6 +96,7 @@ def main(argv, environ):
             "to a Temboard UI."
         ),
         add_help=False,
+        argument_default=UNDEFINED_ARGUMENT,
     )
     define_arguments(parser)
 


### PR DESCRIPTION
Fixes:

    root@d0b3a81:/var/lib/temboard# gosu temboard temboard-agent-register --host agent96 --port 2345 --groups local_instances https://ui:8888
    ERROR: Unhandled error:
    ERROR: Traceback (most recent call last):
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/cli.py", line 41, in cli_wrapper
    ERROR:     retcode = main(argv, environ) or 1
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/scripts/register.py", line 109, in main
    ERROR:     args=args, environ=environ,
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/configuration.py", line 131, in load_configuration
    ERROR:     config.load(args=args, environ=environ)
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/configuration.py", line 228, in load
    ERROR:     self.add_values(iter_args_values(args))
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/configuration.py", line 217, in add_values
    ERROR:     value = spec.validate(value)
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/configuration.py", line 109, in validate
    ERROR:     return self.validator(value.value)
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/validators.py", line 49, in file_
    ERROR:     raw = os.path.realpath(raw)
    ERROR:   File "/usr/local/lib/python2.7/posixpath.py", line 375, in realpath
    ERROR:     path, ok = _joinrealpath('', filename, {})
    ERROR:   File "/usr/local/lib/python2.7/posixpath.py", line 381, in _joinrealpath
    ERROR:     if isabs(rest):
    ERROR:   File "/usr/local/lib/python2.7/posixpath.py", line 54, in isabs
    ERROR:     return s.startswith('/')
    ERROR: AttributeError: 'NoneType' object has no attribute 'startswith'
    ERROR: This is a bug!
    ERROR: Please report traceback to https://github.com/dalibo/temboard-agent/issues! Thanks!