### PR TITLE
New plugin infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.pytest_cache/
 .coverage
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 dist/
 docker-compose.override.yml
 docker-histfile
-temboard_agent.egg-info/
 doc/_build/
+*.egg-info/
 rpm/*.patch
 rpm/temboard-agent-*.tar.gz

--- a/temboardagent/pluginsmgmt.py
+++ b/temboardagent/pluginsmgmt.py
@@ -53,7 +53,7 @@ def load_plugins_configurations(config):
 
     # Loop through each plugin listed in the configuration file.
     for plugin_name in config.temboard['plugins']:
-        logger.info("Loading plugin '%s'." % (plugin_name,))
+        logger.info("Loading legacy plugin '%s'." % (plugin_name,))
         fp_s = None
         try:
             # Loading compat.py file
@@ -87,11 +87,14 @@ def load_plugins_configurations(config):
                                                         [path+'/plugins'])
             module = imp.load_module(plugin_name, fp, pathname, description)
             # Try to run module's configuration() function.
-            logger.info("Loading plugin '%s' configuration." % (plugin_name))
-            plugin_configuration = getattr(module, 'configuration')(config)
+            logger.info(
+                "Loading legacy plugin '%s' configuration." % (plugin_name,))
+            plugin_configuration = getattr(module, 'configuration', None)
             ret.update({module.__name__: plugin_configuration})
+            assert plugin_configuration, "undefined configuration"
+            ret[plugin_name] = plugin_configuration(config)
             logger.info("Done.")
-        except AttributeError as e:
+        except AssertionError as e:
             logger.warn("No configuration: %s", e)
         except Exception as e:
             if fp:

--- a/temboardagent/pluginsmgmt.py
+++ b/temboardagent/pluginsmgmt.py
@@ -81,6 +81,7 @@ def load_plugins_configurations(config):
                 fp_s.close()
             logger.info("Not able to load the compatibility file: compat.py.")
         logger.info("Done.")
+        fp = None
         try:
             # Locate and load the module with imp.
             fp, pathname, description = imp.find_module(plugin_name,

--- a/temboardagent/scripts/agent.py
+++ b/temboardagent/scripts/agent.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 from argparse import ArgumentParser, SUPPRESS as UNDEFINED_ARGUMENT
 from socket import getfqdn
 import logging
@@ -16,6 +18,7 @@ from ..daemon import (
 )
 from ..httpd import httpd_run
 from ..queue import purge_queue_dir
+from ..pluginsmgmt import load_plugins
 from .. import validators as v
 
 
@@ -108,6 +111,7 @@ def main(argv, environ):
 
     config.setup_logging()
     logger.info("Starting main process.")
+    load_plugins(config)
 
     # Purge all data queues at start time excepting metrics & notifications.
     purge_queue_dir(config.temboard['home'],

--- a/temboardagent/scripts/agent.py
+++ b/temboardagent/scripts/agent.py
@@ -19,7 +19,7 @@ from ..queue import purge_queue_dir
 from .. import validators as v
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('temboardagent.scripts.agent')
 
 
 def define_arguments(parser):

--- a/test/temboard-agent-sample-plugins/README.md
+++ b/test/temboard-agent-sample-plugins/README.md
@@ -1,0 +1,9 @@
+# Sample External Plugins
+
+This dumb project provides real external plugins to temboard agent.
+
+Use it as following:
+
+- Setup project with `python setup.py egg_info` in this directory.
+- Enter the container and install the project with `pip install -e /usr/local/src/temboard-agent/test/temboard-agent-sample-plugins/`.
+- Run the agent with plugins : `TEMBOARD_PLUGINS='["hellong", "failing"]' gosu temboard temboard-agent`. `

--- a/test/temboard-agent-sample-plugins/setup.py
+++ b/test/temboard-agent-sample-plugins/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(
+    name='temboard-agent-sample-plugins',
+    version='1.0',
+    author='Dalibo',
+    author_email='contact@dalibo.com',
+    license='PostgreSQL',
+    install_requires=['temboard-agent'],
+    py_modules=['temboard_agent_sample_plugins'],
+    entry_points={
+        'temboardagent.plugins': [
+            'failing = temboard_agent_sample_plugins:Failing',
+            'hellong = temboard_agent_sample_plugins:Hello',
+            'inexistant = temboard_agent_sample_plugins:INEXISTANT',
+        ],
+    },
+)

--- a/test/temboard-agent-sample-plugins/temboard_agent_sample_plugins.py
+++ b/test/temboard-agent-sample-plugins/temboard_agent_sample_plugins.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+import logging
+
+
+logger = logging.getLogger('temboardagent.' + __name__)
+
+
+class Hello(object):
+    def __init__(self):
+        logger.info("hello code running. Over.")
+
+
+class Failing(object):
+    def __init__(self):
+        assert False, "Plugins fails to load."

--- a/test/unit/test_plugins.py
+++ b/test/unit/test_plugins.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+import pytest
+
+
+def test_fetch_plugins(mocker):
+    iter_ep = mocker.patch('temboardagent.pluginsmgmt.iter_entry_points')
+    from temboardagent.pluginsmgmt import PluginManager
+
+    manager = PluginManager(mocker.Mock(name='config'))
+    manager.config.temboard.plugins = ['myplugin']
+    manager.config.plugins = dict()
+    iter_ep.return_value = [mocker.Mock(name='found', ep='found')]
+
+    eps = list(manager.fetch_plugins())
+
+    assert 1 == len(eps)
+    assert 'found' == eps[0].ep
+
+
+def test_fetch_plugins_legacy(mocker):
+    iter_ep = mocker.patch('temboardagent.pluginsmgmt.iter_entry_points')
+    from temboardagent.pluginsmgmt import PluginManager
+
+    manager = PluginManager(mocker.Mock(name='config'))
+    manager.config.temboard.plugins = ['legacy']
+    manager.config.plugins = dict(legacy=None)
+    iter_ep.side_effect = Exception('not called')
+
+    assert not list(manager.fetch_plugins())
+
+
+def test_fetch_missing(mocker):
+    iter_ep = mocker.patch('temboardagent.pluginsmgmt.iter_entry_points')
+    from temboardagent.pluginsmgmt import PluginManager, ConfigurationError
+
+    manager = PluginManager(mocker.Mock(name='config'))
+    manager.config.temboard.plugins = ['myplugin']
+    manager.config.plugins = dict()
+    iter_ep.return_value = []
+
+    with pytest.raises(ConfigurationError):
+        list(manager.fetch_plugins())
+
+
+def test_load_plugins(mocker):
+    from temboardagent.pluginsmgmt import PluginManager, ConfigurationError
+
+    manager = PluginManager()
+    ep = mocker.Mock()
+    ep.name = 'myplugin'
+    manager.load_plugins([ep])
+    assert 'myplugin' in manager.plugins
+
+    manager = PluginManager()
+    ep = mocker.Mock()
+    ep.load.side_effect = Exception('fail to load')
+    with pytest.raises(ConfigurationError):
+        manager.load_plugins([ep])
+    assert not manager.plugins


### PR DESCRIPTION
cf. #131 

With this PR :

- temboardagent loads a plugin either new or legacy
- A missing plugin triggers a fatal error. This may be a typo
- A sample **external** plugin is available to test.

What's not yet here:

- extending configuration
- hot unload
- compatibility check from plugin