### PR TITLE
Add max_connections to dashboard metrics

### DIFF
--- a/temboardagent/plugins/dashboard/__init__.py
+++ b/temboardagent/plugins/dashboard/__init__.py
@@ -177,6 +177,7 @@ Get the last ``n`` sets of dashboard data. ``n`` is defined by parameter ``histo
                 "nb": 1,
                 "time": 1492703660.798522
             },
+            "max_connections": 100,
             "databases":
             {
                 "total_rollback": 1081,
@@ -760,6 +761,48 @@ Get a bunch of global informations about system and PostgreSQL.
                                    sessions,
                                    metrics,
                                    'get_info')
+
+
+@add_route('GET', '/dashboard/max_connections')
+def dashboard_max_connections(http_context,
+                              config=None,
+                              sessions=None):
+    """
+Get the max_connections settings value.
+
+.. sourcecode:: http
+
+    GET /dashboard/active_backends HTTP/1.1
+    X-Session: 3b28ed94743e3ada57b217bbf9f36c6d1eb45e669a1ab693e8ca7ac3bd070b9e
+
+
+**Example response**:
+
+.. sourcecode:: http
+
+    HTTP/1.0 200 OK
+    Server: temboard-agent/0.0.1 Python/2.7.12
+    Date: Thu, 20 Apr 2017 16:35:55 GMT
+    Access-Control-Allow-Origin: *
+    Content-type: application/json
+
+    {
+        "max_connections": 100
+    }
+
+:reqheader X-Session: Session ID
+:statuscode 200: no error
+:statuscode 401: invalid session
+:statuscode 500: internal error
+:statuscode 406: header ``X-Session`` is malformed.
+
+
+    """  # noqa
+    return api_function_wrapper_pg(config,
+                                   http_context,
+                                   sessions,
+                                   metrics,
+                                   'get_max_connections')
 
 
 def dashboard_worker_sigterm_handler(signum, frame):

--- a/temboardagent/plugins/dashboard/metrics.py
+++ b/temboardagent/plugins/dashboard/metrics.py
@@ -14,6 +14,7 @@ def get_metrics(conn, config, _=None):
     return {'buffers': dm.get_buffers(),
             'hitratio': dm.get_hitratio(),
             'active_backends': dm.get_active_backends(),
+            'max_connections': dm.get_max_connections(),
             'cpu': dm.get_cpu_usage(),
             'loadaverage': dm.get_load_average(),
             'memory': dm.get_memory_usage(),
@@ -72,6 +73,11 @@ def get_hitratio(conn, config, _):
 def get_active_backends(conn, config, _):
     dm = DashboardMetrics(conn)
     return {'active_backends': dm.get_active_backends()}
+
+
+def get_max_connections(conn, config, _):
+    dm = DashboardMetrics(conn)
+    return {'max_connections': dm.get_max_connections()}
 
 
 def get_cpu_usage(config, _):
@@ -155,6 +161,13 @@ class DashboardMetrics(object):
         current_active_backends = self._get_current_active_backends()
         return {'nb': current_active_backends,
                 'time': current_time}
+
+    def get_max_connections(self):
+        query = """
+SELECT setting FROM pg_settings WHERE name = 'max_connections'
+            """
+        self.conn.execute(query)
+        return int(list(self.conn.get_rows())[0]['setting'])
 
     def get_cpu_usage(self,):
         sysinfo = SysInfo()

--- a/test/legacy/test_dashboard.py
+++ b/test/legacy/test_dashboard.py
@@ -85,6 +85,7 @@ class TestDashboard:
         dict_data = json.loads(res)
         assert status == 200 \
             and 'active_backends' in dict_data \
+            and 'max_connections' in dict_data \
             and 'loadaverage' in dict_data \
             and 'os_version' in dict_data \
             and 'pg_version' in dict_data \
@@ -401,3 +402,26 @@ class TestDashboard:
         assert status == 200 \
             and 'n_cpu' in dict_data \
             and type(dict_data['n_cpu']) == int
+
+
+    def test_13_dashboard_max_connections_ok(self):
+        """
+        [dashboard] 13: GET /dashboard/max_connections : HTTP return code is 200 and the data structure is right
+        """  # noqa
+        (status, res) = temboard_request(
+                ENV['agent']['ssl_cert_file'],
+                method='GET',
+                url='https://%s:%s/dashboard/max_connections' % (
+                        ENV['agent']['host'],
+                        ENV['agent']['port']
+                        ),
+                headers={
+                    "Content-type": "application/json",
+                    "X-Session": XSESSION
+                }
+            )
+        dict_data = json.loads(res)
+
+        assert status == 200 \
+            and 'max_connections' in dict_data \
+            and type(dict_data['max_connections']) == int


### PR DESCRIPTION
In order to be displayed in the new sessions chart as a comparison to `active_backends`.