### PR TITLE
Add some information to metrics

### DIFF
--- a/temboardagent/inventory.py
+++ b/temboardagent/inventory.py
@@ -83,6 +83,12 @@ class SysInfo(Inventory):
         else:
             raise Exception("Unsupported OS.")
 
+    def linux_distribution(self):
+        if self.os == 'Linux':
+            return " ".join(platform.linux_distribution()).strip()
+        else:
+            raise Exception("Unsupported OS.")
+
     def _hostname_linux(self):
         """
         Returns system hostname.

--- a/temboardagent/plugins/dashboard/metrics.py
+++ b/temboardagent/plugins/dashboard/metrics.py
@@ -11,6 +11,12 @@ def get_metrics(conn, config, _=None):
     dm = DashboardMetrics(conn)
     sysinfo = SysInfo()
     pginfo = PgInfo(conn)
+
+    cpu_models = [cpu['model_name'] for cpu in sysinfo.cpu_info()['cpus']]
+    cpu_models_counter = {}
+    for elem in cpu_models:
+        cpu_models_counter[elem] = cpu_models_counter.get(elem, 0) + 1
+
     return {'buffers': dm.get_buffers(),
             'hitratio': dm.get_hitratio(),
             'active_backends': dm.get_active_backends(),
@@ -19,7 +25,9 @@ def get_metrics(conn, config, _=None):
             'loadaverage': dm.get_load_average(),
             'memory': dm.get_memory_usage(),
             'hostname': sysinfo.hostname(config.temboard['hostname']),
-            'os_version': "%s %s" % (sysinfo.os, sysinfo.os_release),
+            'os_version': sysinfo.os_release,
+            'linux_distribution': sysinfo.linux_distribution(),
+            'cpu_models': cpu_models_counter,
             'databases': dm.get_stat_db(),
             'pg_uptime': dm.get_pg_uptime(),
             'n_cpu': sysinfo.n_cpu(),

--- a/test/legacy/test_dashboard.py
+++ b/test/legacy/test_dashboard.py
@@ -88,6 +88,9 @@ class TestDashboard:
             and 'max_connections' in dict_data \
             and 'loadaverage' in dict_data \
             and 'os_version' in dict_data \
+            and 'linux_distribution' in dict_data \
+            and 'cpu_models' in dict_data \
+            and isinstance(dict_data['cpu_models'], dict) \
             and 'pg_version' in dict_data \
             and 'n_cpu' in dict_data \
             and 'hitratio' in dict_data \


### PR DESCRIPTION
 - linux distribution,
 - os_version is now kernel version,
 - cpu models with count for each model```

Here are the relevant changes:
Before:
```json
{
    "os_version": "Linux 4.8.0-53-generic"
}
```

After:
```json
{
    "os_version": "4.8.0-53-generic",
    "linux_distribution": "debian 8.10",
    "cpu_models": {
        "Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz": 4
    }
}
```

I prefered not to change the `os_version` keyword to avoid compatibility issues as much as possible. An other possibility would be to add a new keyword.