### PR TITLE
WIP - Dashboard empty history

### DIFF
--- a/temboardagent/plugins/dashboard/metrics.py
+++ b/temboardagent/plugins/dashboard/metrics.py
@@ -38,9 +38,7 @@ def get_metrics(conn, config, _=None):
 
 
 def get_metrics_queue(config, _=None):
-    q = Queue('%s/dashboard.q' % (config.temboard['home']),
-              max_length=(config.plugins['dashboard']['history_length']+1),
-              overflow_mode='slide')
+    q = Queue('%s/dashboard.q' % (config.temboard['home']))
     dm = DashboardMetrics()
     msg = q.get_last_message()
     msg['notifications'] = dm.get_notifications(config)
@@ -48,9 +46,7 @@ def get_metrics_queue(config, _=None):
 
 
 def get_history_metrics_queue(config, _=None):
-    q = Queue('%s/dashboard.q' % (config.temboard['home']),
-              max_length=(config.plugins['dashboard']['history_length']+1),
-              overflow_mode='slide')
+    q = Queue('%s/dashboard.q' % (config.temboard['home']))
     return q.get_content_all_messages()
 
 


### PR DESCRIPTION
With this PR the dashboard history file (queue) is filled with some initial value so that on the client the history charts (loadaverage and TPS) actually show data corresponding to the `history_length` config paramater even when the agent was recently started.

![localhost_8888_server_agent_2345_dashboard 1280](https://user-images.githubusercontent.com/319774/38033185-c35641c0-329f-11e8-919b-00b1a0ccc825.png)

We could go a step further by setting `null` to some data (for example loadaverage).