### PR TITLE
Manage scheduler and workerpool processes

### DIFF
--- a/temboardagent/log.py
+++ b/temboardagent/log.py
@@ -97,7 +97,9 @@ def generate_logging_config(
         HANDLERS['stderr']['()'] = __name__ + '.ColoredStreamHandler'
 
     minimal_fmt = '%(levelname)5.5s: %(message)s'
-    verbose_fmt = '%(asctime)s [%(lastname)-16.16s] ' + minimal_fmt
+    verbose_fmt = (
+        '%(asctime)s [%(process)5d] [%(lastname)-16.16s] ' + minimal_fmt
+    )
     syslog_fmt = (
         "temboard-agent[%(process)d]: "
         "[%(lastname)s] %(levelname)s: %(message)s"

--- a/temboardagent/plugins/activity/__init__.py
+++ b/temboardagent/plugins/activity/__init__.py
@@ -59,3 +59,6 @@ class ActivityPlugin(object):
         add_route('GET', '/activity')(get_activity)
         add_route('GET', '/activity/waiting')(get_activity_waiting)
         add_route('GET', '/activity/blocking')(get_activity_blocking)
+
+    def unload(self):
+        pass

--- a/temboardagent/services.py
+++ b/temboardagent/services.py
@@ -1,8 +1,13 @@
+# coding: utf-8
+
 from __future__ import unicode_literals
 
 import logging
 import os
+from multiprocessing import Process
 import signal
+from time import sleep
+import sys
 
 from .utils import setproctitle
 
@@ -13,10 +18,19 @@ logger = logging.getLogger(__name__)
 class Service(object):
     # Manage long running process. This include setup, signal management and
     # loop.
+    #
+    # There is two kind of services : main service and child services. Main
+    # service is responsible to duplicate signals to children with
+    # ServicesManager.
 
-    def __init__(self, app, name=None):
+    def __init__(self, app, name=None, services=None):
         self.app = app
         self.name = name
+        # Must be None for children or ServicesManager instance for main
+        # service. Used to propagate signals. See reload() method.
+        self.services = services
+        self.pid = None
+        self.parentpid = None
 
     def __unicode__(self):
         return '%s (pid=%s)' % (self.name, self.pid)
@@ -29,6 +43,17 @@ class Service(object):
     def __exit__(self, *a):
         signal.signal(signal.SIGHUP, signal.SIG_DFL)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    def check_parent_running(self):
+        if self.parentpid is None:
+            # If no parentpid, we are the main service. We are running.
+            return True
+
+        try:
+            os.kill(self.parentpid, 0)
+            return True
+        except OSError:
+            return False
 
     def sighup_handler(self, *a):
         self.sighup = True
@@ -46,13 +71,22 @@ class Service(object):
     def serve(self):
         with self:
             while True:
+                if not self.check_parent_running():
+                    logger.warn(
+                        "Parent process %d is dead. Committing suicide.",
+                        self.parentpid)
+                    sys.exit(1)
+
                 if self.sighup:
                     self.sighup = False
                     self.reload()
+
                 self.serve1()
 
     def reload(self):
         self.app.reload()
+        if self.services:
+            self.services.reload()
 
     def setup(self):
         # This method is called once before looping to prepare the service:
@@ -64,3 +98,54 @@ class Service(object):
         # This method should not block for too long waiting for work to be
         # done. Reload is applied between two calls of this method.
         raise NotImplemented
+
+
+class ServicesManager(object):
+    # Manage child services : starting in background, tracking PID, replicating
+    # signals, checking status, stopping and killing.
+    #
+    # Add a service with services_manager.add(Service(…)).
+    #
+    # As a context manager, services are started on enter and stopped-killed on
+    # exit.
+
+    def __init__(self):
+        self.processes = []
+        self.pid = os.getpid()
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, *a):
+        self.stop()
+        logger.debug("Waiting background services.")
+        sleep(0.25)
+        self.kill()
+
+    def add(self, service):
+        service.parentpid = self.pid
+        self.processes.append(Process(target=service.run))
+
+    def start(self):
+        for process in self.processes:
+            process.start()
+
+    def reload(self):
+        for process in self.processes:
+            os.kill(process.pid, signal.SIGHUP)
+
+    def stop(self):
+        for process in self.processes:
+            process.terminate()
+
+    def kill(self, timeout=5, step=0.5):
+        while timeout > 0:
+            processes = [p for p in self.processes if p.is_alive()]
+            if not processes:
+                break
+            sleep(step)
+            timeout -= step
+
+        for process in processes:
+            logger.warn("Killing %s.", process)
+            os.kill(process.pid, signal.SIGKILL)

--- a/temboardagent/services.py
+++ b/temboardagent/services.py
@@ -18,6 +18,9 @@ class Service(object):
         self.app = app
         self.name = name
 
+    def __unicode__(self):
+        return '%s (pid=%s)' % (self.name, self.pid)
+
     def __enter__(self):
         signal.signal(signal.SIGHUP, self.sighup_handler)
         signal.signal(signal.SIGTERM, self.sigterm_handler)

--- a/temboardagent/services.py
+++ b/temboardagent/services.py
@@ -59,7 +59,8 @@ class Service(object):
         self.sighup = True
 
     def sigterm_handler(self, *a):
-        os._exit(1)
+        logger.info("Terminated.")
+        sys.exit(1)
 
     def run(self):
         if self.name:

--- a/temboardagent/services.py
+++ b/temboardagent/services.py
@@ -67,7 +67,11 @@ class Service(object):
             setproctitle('temboard-agent: %s' % self.name)
 
         self.setup()
-        self.serve()
+        try:
+            self.serve()
+        except KeyboardInterrupt:
+            logger.info("Interrupted.")
+            sys.exit(1)
 
     def serve(self):
         with self:


### PR DESCRIPTION
cf. #131 

This PR :

- adds hot load/unload of plugins in every processes
- set proctitle to every process
- clean exit on INT and TERM, pidfile is cleaned
- suicide on parent KILL


Logs with dalibo/temboard-sched#21 :

# Starting :

``` console
root@ece65fba2b23:/var/lib/temboard# DEBUG=1 sudo -u temboard temboard-agent                                                                                                                                                            
2018-04-04 16:41:13,926 [  437] [cli             ] DEBUG: Starting temBoard agent.                                                                                                                                                      
2018-04-04 16:41:13,928 [  437] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.                                                                                                                              2018-04-04 16:41:13,933 [  437] [agent           ]  INFO: Starting main process.                                            
2018-04-04 16:41:13,935 [  439] [services        ]  INFO: scheduler (pid=439) running in background.                                                                                                                                    2018-04-04 16:41:13,936 [  437] [utils           ] DEBUG: argv is at c_char_p(140736443026484), len=39.                                                                                                                                 2018-04-04 16:41:13,936 [  439] [utils           ] DEBUG: argv is at c_char_p(140736443026484), len=39.                                                                                                                                 2018-04-04 16:41:13,936 [  440] [services        ]  INFO: worker pool (pid=440) running in background.                                                                                                                                  2018-04-04 16:41:13,937 [  440] [utils           ] DEBUG: argv is at c_char_p(140736443026484), len=39.     
...                                                                                                                           
```

# process title :

``` console
root@ece65fba2b23:/usr/local/src/temboard-agent# ps -efH
UID        PID  PPID  C STIME TTY          TIME CMD
root       253     0  0 15:50 ?        00:00:00 bash
root       443   253  0 16:42 ?        00:00:00   sudo -u temboard temboard-agent
temboard   444   443  5 16:42 ?        00:00:00     temboard-agent: main process
temboard   446   444  0 16:42 ?        00:00:00       temboard-agent: scheduler
temboard   447   444  0 16:42 ?        00:00:00       temboard-agent: worker pool
```

# Daemonize:

``` console
root@ece65fba2b23:/var/lib/temboard# sudo -u temboard temboard-agent -d -p ${PWD}/temboard.pid
 INFO: Reading /etc/temboard-agent/temboard-agent.conf.
root@ece65fba2b23:/var/lib/temboard# kill -0 $(cat temboard.pid)
root@ece65fba2b23:/var/lib/temboard# echo $?
0
root@ece65fba2b23:/var/lib/temboard# ps -efH
UID        PID  PPID  C STIME TTY          TIME CMD
temboard   459     0  0 16:44 ?        00:00:00 temboard-agent: main process
temboard   460   459  0 16:44 ?        00:00:00   temboard-agent: scheduler
temboard   461   459  0 16:44 ?        00:00:00   temboard-agent: worker pool
root       253     0  0 15:50 ?        00:00:00 bash
root       464   253  0 16:44 ?        00:00:00   ps -efH
root@ece65fba2b23:/var/lib/temboard# kill $(cat temboard.pid )
root@ece65fba2b23:/var/lib/temboard# ps -efH
UID        PID  PPID  C STIME TTY          TIME CMD
root       253     0  0 15:50 ?        00:00:00 bash
root       466   253  0 16:46 ?        00:00:00   ps -efH
root@ece65fba2b23:/var/lib/temboard#
```

# Reloading :

Started with `plugins = ["monitoring", "activity", "dashboard", "administration", "pgconf", "hellong"]`.

```
...
### plugins = []
2018-04-04 18:37:57,628 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:37:57,629 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:37:57,748 [  566] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:37:57,749 [  566] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:37:57,758 [  566] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:37:57,758 [  566] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:37:57,758 [  566] [cli             ]  INFO: Unloading plugin activity.
2018-04-04 18:37:57,758 [  566] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:37:57,759 [  568] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:37:57,759 [  569] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:37:57,759 [  568] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:37:57,759 [  569] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:37:57,768 [  569] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:37:57,769 [  569] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:37:57,769 [  569] [cli             ]  INFO: Unloading plugin activity.
2018-04-04 18:37:57,769 [  569] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:37:57,768 [  568] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:37:57,769 [  568] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:37:57,769 [  568] [cli             ]  INFO: Unloading plugin activity.
2018-04-04 18:37:57,769 [  568] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:37:57,770 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:37:58,771 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:37:58,772 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
...
### plugins = ["hellong"]
2018-04-04 18:38:18,821 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:19,822 [  568] [taskmanager     ] DEBUG: Scheduling                 
2018-04-04 18:38:19,823 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:20,627 [  566] [cli             ] WARNI: Reloading configuration.   
2018-04-04 18:38:20,628 [  566] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:20,647 [  566] [pluginsmgmt     ]  INFO: Loading legacy plugin 'hellong'.
2018-04-04 18:38:20,648 [  566] [pluginsmgmt     ]  INFO: Not able to load the compatibility file: compat.py.
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ]  INFO: Done.                      
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ] ERROR: No module named hellong
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ] ERROR: Traceback (most recent call last):
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ] ERROR:   File "/usr/local/src/temboard-agent/temboardagent/pluginsmgmt.py", line 89, in load_plugins_configurations
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ] ERROR:     [path+'/plugins'])
2018-04-04 18:38:20,649 [  566] [pluginsmgmt     ] ERROR: ImportError: No module named hellong
2018-04-04 18:38:20,651 [  566] [pluginsmgmt     ]  INFO: Failed.
2018-04-04 18:38:20,651 [  566] [cli             ] DEBUG: Looking for plugin hellong.
2018-04-04 18:38:20,652 [  566] [cli             ]  INFO: Found plugin hellong = temboard_agent_sample_plugins:Hello.
2018-04-04 18:38:20,654 [  566] [cli             ] DEBUG: Reading new plugins configuration.
2018-04-04 18:38:20,657 [  566] [cli             ]  INFO: Loading plugin hellong.
2018-04-04 18:38:20,667 [  566] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:20,668 [  569] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:38:20,668 [  568] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:38:20,669 [  569] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:20,669 [  568] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:20,679 [  569] [pluginsmgmt     ]  INFO: Loading legacy plugin 'hellong'.
2018-04-04 18:38:20,679 [  568] [pluginsmgmt     ]  INFO: Loading legacy plugin 'hellong'.
2018-04-04 18:38:20,680 [  568] [pluginsmgmt     ]  INFO: Not able to load the compatibility file: compat.py.
2018-04-04 18:38:20,680 [  568] [pluginsmgmt     ]  INFO: Done.
2018-04-04 18:38:20,680 [  569] [pluginsmgmt     ]  INFO: Not able to load the compatibility file: compat.py.
2018-04-04 18:38:20,680 [  569] [pluginsmgmt     ]  INFO: Done.
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ] ERROR: No module named hellong
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ] ERROR: Traceback (most recent call last):
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ] ERROR:   File "/usr/local/src/temboard-agent/temboardagent/pluginsmgmt.py", line 89, in load_plugins_configurations
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ] ERROR:     [path+'/plugins'])
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ] ERROR: ImportError: No module named hellong
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ] ERROR: No module named hellong
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ] ERROR: Traceback (most recent call last):
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ] ERROR:   File "/usr/local/src/temboard-agent/temboardagent/pluginsmgmt.py", line 89, in load_plugins_configurations
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ] ERROR:     [path+'/plugins'])
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ] ERROR: ImportError: No module named hellong
2018-04-04 18:38:20,681 [  569] [pluginsmgmt     ]  INFO: Failed.
2018-04-04 18:38:20,681 [  568] [pluginsmgmt     ]  INFO: Failed.
2018-04-04 18:38:20,681 [  569] [cli             ] DEBUG: Looking for plugin hellong.
2018-04-04 18:38:20,681 [  568] [cli             ] DEBUG: Looking for plugin hellong.
2018-04-04 18:38:20,682 [  569] [cli             ]  INFO: Found plugin hellong = temboard_agent_sample_plugins:Hello.
2018-04-04 18:38:20,682 [  568] [cli             ]  INFO: Found plugin hellong = temboard_agent_sample_plugins:Hello.
2018-04-04 18:38:20,682 [  569] [cli             ] DEBUG: Reading new plugins configuration.
2018-04-04 18:38:20,682 [  568] [cli             ] DEBUG: Reading new plugins configuration.
2018-04-04 18:38:20,683 [  569] [cli             ]  INFO: Loading plugin hellong.
2018-04-04 18:38:20,683 [  568] [cli             ]  INFO: Loading plugin hellong.
2018-04-04 18:38:20,686 [  568] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:20,686 [  569] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:20,687 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:21,689 [  568] [taskmanager     ] DEBUG: Scheduling
...
### plugins = []
2018-04-04 18:38:50,758 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:51,759 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:38:51,760 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:52,762 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:38:52,763 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:52,799 [  566] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:38:52,800 [  566] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:52,818 [  566] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:38:52,819 [  566] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:38:52,819 [  566] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:52,820 [  568] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:38:52,820 [  569] [cli             ] WARNI: Reloading configuration.
2018-04-04 18:38:52,821 [  569] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:52,821 [  568] [cli             ]  INFO: Reading /etc/temboard-agent/temboard-agent.conf.
2018-04-04 18:38:52,835 [  569] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:38:52,836 [  568] [cli             ]  INFO: Unloading plugin hellong.
2018-04-04 18:38:52,836 [  569] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:38:52,836 [  568] [temboard_agent_s]  INFO: Good by from hellong!
2018-04-04 18:38:52,837 [  568] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:52,837 [  569] [cli             ]  INFO: Configuration reloaded.
2018-04-04 18:38:52,837 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:53,838 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:38:53,839 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 18:38:54,841 [  568] [taskmanager     ] DEBUG: Scheduling
2018-04-04 18:38:54,842 [  568] [taskmanager     ] DEBUG: Select on Listener with t=1
...
```

# Stopping :

``` console
2018-04-04 16:43:00,804 [  446] [taskmanager     ] DEBUG: Select on Listener with t=1
2018-04-04 16:43:01,806 [  446] [taskmanager     ] DEBUG: Scheduling
2018-04-04 16:43:01,807 [  446] [taskmanager     ] DEBUG: Select on Listener with t=1
^C2018-04-04 16:43:02,447 [  444] [services        ] DEBUG: Waiting background services.
2018-04-04 16:43:03,200 [  444] [cli             ]  INFO: Terminated.
root@ece65fba2b23:/var/lib/temboard# ps -efH
UID        PID  PPID  C STIME TTY          TIME CMD
root       253     0  0 15:50 ?        00:00:00 bash
root       451   253  0 16:43 ?        00:00:00   ps -efH
root@ece65fba2b23:/var/lib/temboard#
```

# Killing parent process:

```
2018-04-04 16:39:41,534 [  427] [taskmanager     ] DEBUG: Scheduling
2018-04-04 16:39:41,534 [  427] [taskmanager     ] DEBUG: Select on Listener with t=1
root@ece65fba2b23:/var/lib/temboard# 2018-04-04 16:39:41,667 [  428] [services        ] WARNI: Parent process 425 is dead. Committing suicide.
2018-04-04 16:39:42,536 [  427] [taskmanager     ] DEBUG: Scheduling
2018-04-04 16:39:42,537 [  427] [services        ] WARNI: Parent process 425 is dead. Committing suicide.
```

# Legacy tests

``` console
$ make run
docker-compose up                                                                                                
Starting tbawf_tests_centos7_pg96_1 ...                                                                              
Starting tbawf_centos6_pg10_1 ...                                                                                    
Starting tbawf_tests_centos7_pg96_1                                                                               
Starting tbawf_tests_centos7_pg94_1 ...                                                                         
Starting tbawf_tests_centos7_pg95_1 ...                                                                                  
Starting tbawf_tests_centos7_pg10_1 ...                                                                          
Starting tbawf_centos6_pg10_1                                                                                 
Starting tbawf_tests_centos7_pg94_1                                                                                      
Starting tbawf_tests_centos7_pg95_1                                                                                  
Starting tbawf_tests_centos7_pg95_1 ... done                                                                         
Attaching to tbawf_tests_centos7_pg96_1, tbawf_centos6_pg10_1, tbawf_tests_centos7_pg10_1, tbawf_tests_centos7_pg94_1, tbawf_tests_centos7_pg95_1
tests_centos7_pg96_1  | ++ readlink -m /workspace/test/legacy/run_tests_docker.sh/../../..                         
tests_centos7_pg96_1  | + top_srcdir=/workspace                                                                        
tests_centos7_pg96_1  | + cd /workspace                                                                                
....
tests_centos7_pg96_1  | ========================= 95 passed in 107.90 seconds ==========================
tests_centos7_pg96_1  | + teardown
tests_centos7_pg96_1  | + exit_code=0
tests_centos7_pg96_1  | + '[' -z '' -a 1 = 1 -a 0 -gt 0 ']'
tests_centos7_pg94_1  | test/legacy/test_pgconf.py::TestPgconf::test_52_post_pgconf_pg_ident_ko_406 PASSED
tests_centos7_pg94_1  |
tests_centos7_pg94_1  | ========================= 95 passed in 106.88 seconds ==========================
tests_centos7_pg94_1  | + teardown
tests_centos7_pg94_1  | + exit_code=0
tests_centos7_pg94_1  | + '[' -z '' -a 1 = 1 -a 0 -gt 0 ']'
tests_centos7_pg95_1  | test/legacy/test_pgconf.py::TestPgconf::test_52_post_pgconf_pg_ident_ko_406 PASSED
tests_centos7_pg95_1  |
tests_centos7_pg95_1  | ========================= 95 passed in 106.69 seconds ==========================
tbawf_tests_centos7_pg96_1 exited with code 0
tests_centos7_pg95_1  | + teardown
tests_centos7_pg95_1  | + exit_code=0
tests_centos7_pg95_1  | + '[' -z '' -a 1 = 1 -a 0 -gt 0 ']'
tbawf_tests_centos7_pg94_1 exited with code 0
tbawf_tests_centos7_pg95_1 exited with code 0
if docker-compose ps | grep 'Exit [1-9]' ; then exit 1; fi
$

````
```
