### PR TITLE
 Fasten CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2
 
+.func-job: &func-job
+  working_directory: /workspace
+  steps:
+  - checkout
+  - attach_workspace:
+      at: /workspace
+  - run:
+      name: Execute the tests
+      command: TBD_INSTALL_RPM=1 test/legacy/run_tests_docker.sh
+
 jobs:
   0-doc:
     docker: [{image: "python:2.7"}]
@@ -79,23 +89,33 @@ jobs:
           paths:
             - "~/.cache/pip/"
 
-  1-func:
-    machine: true
-    steps:
-    - checkout
-    - run: git submodule update --init --depth=1
-    - attach_workspace:
-        at: ~/project
-    - run:
-        name: Install Docker Compose
-        command: |
-          set -x
-          curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` | sudo tee /usr/local/bin/docker-compose > /dev/null
-          sudo chmod +x /usr/local/bin/docker-compose
-    - run:
-        name: Execute the tests
-        command: |
-          TBD_INSTALL_RPM=1 make -C test/legacy build run
+  1-func-centos7-pg10:
+    docker:
+    - image: dalibo/temboard-agent-sdk:centos7
+      environment:
+        TBD_PGBIN: /usr/pgsql-10/bin
+    <<: *func-job
+
+  1-func-centos7-pg96:
+    docker:
+    - image: dalibo/temboard-agent-sdk:centos7
+      environment:
+        TBD_PGBIN: /usr/pgsql-9.6/bin
+    <<: *func-job
+
+  1-func-centos7-pg95:
+    docker:
+    - image: dalibo/temboard-agent-sdk:centos7
+      environment:
+        TBD_PGBIN: /usr/pgsql-9.5/bin
+    <<: *func-job
+
+  1-func-centos6-pg94:
+    docker:
+    - image: dalibo/temboard-agent-sdk:centos6
+      environment:
+        TBD_PGBIN: /usr/pgsql-9.4/bin
+    <<: *func-job
 
 
 workflows:
@@ -106,5 +126,11 @@ workflows:
     - 0-rpm-centos6
     - 0-rpm-centos7
     - 0-unit
-    - 1-func:
-        requires: [0-rpm-centos6, 0-rpm-centos7, 0-unit]
+    - 1-func-centos7-pg10:
+        requires: [0-rpm-centos7, 0-unit]
+    - 1-func-centos7-pg96:
+        requires: [0-rpm-centos7, 0-unit]
+    - 1-func-centos7-pg95:
+        requires: [0-rpm-centos7, 0-unit]
+    - 1-func-centos6-pg94:
+        requires: [0-rpm-centos6, 0-unit]

--- a/test/legacy/Makefile
+++ b/test/legacy/Makefile
@@ -5,3 +5,7 @@ run:
 
 shell:
 	docker-compose exec test /bin/bash
+
+PYTEST_ARGS?=
+pytest:
+	TBD_WORKPATH="/tmp" sudo -Eu testuser pytest -vs -p no:cacheprovider ./ $(PYTEST_ARGS)

--- a/test/legacy/Makefile
+++ b/test/legacy/Makefile
@@ -1,9 +1,7 @@
 default:
 
-build:
-	docker build -t dalibo/temboard-agent-func:centos6 -f Dockerfile.centos6 .
-	docker build -t dalibo/temboard-agent-func:centos7 -f Dockerfile.centos7 .
-
 run:
-	docker-compose up
-	if docker-compose ps | grep 'Exit [1-9]' ; then exit 1; fi
+	docker-compose up --exit-code-from test --abort-on-container-exit test
+
+shell:
+	docker-compose exec test /bin/bash

--- a/test/legacy/README.md
+++ b/test/legacy/README.md
@@ -34,7 +34,13 @@ Defaults to `centos7`.
 Choose Postgres version from `9.4` to `10` with envvar `POSTGRES_VERSION`.
 Defaults to `10`.
 
+In case of failure, the container wait for you to enter and debug with `make
+shell`
+
 ``` console
-# TAG=centos7 POSTGRES_VERSION=9.5 make run
-# make shell
+$ TAG=centos7 POSTGRES_VERSION=9.5 make run
+…
+$ make shell
+[root@3e8037d18e8b /]# make -C test/legacy pytest PYTEST_ARGS="-x --pdb"
+…
 ```

--- a/test/legacy/README.md
+++ b/test/legacy/README.md
@@ -28,6 +28,13 @@ TBD_PGBIN="/path/to/pg/9.6/bin" TBD_WORKPATH="/tmp" pytest -v test/legacy/test_*
 
 You can also run the tests via docker for several versions of Postgres.
 
-```
-make build run
+Choose CentOS version between `centos6` and `centos7` with envvar `TAG`.
+Defaults to `centos7`.
+
+Choose Postgres version from `9.4` to `10` with envvar `POSTGRES_VERSION`.
+Defaults to `10`.
+
+``` console
+# TAG=centos7 POSTGRES_VERSION=9.5 make run
+# make shell
 ```

--- a/test/legacy/docker-compose.yml
+++ b/test/legacy/docker-compose.yml
@@ -1,49 +1,12 @@
-version: '2'
+version: '3'
 
 services:
-  centos6_pg10:
-    image: dalibo/temboard-agent-func:centos6
+  test:
+    image: dalibo/temboard-agent-sdk:${TAG-centos7}
     volumes:
     - ../../:/workspace
     environment:
       - CI
-      - TBD_PGBIN=/usr/pgsql-10/bin
-      - TBD_INSTALL_RPM
-    command: /workspace/test/legacy/run_tests_docker.sh
-
-  tests_centos7_pg94:
-    image: dalibo/temboard-agent-func:centos7
-    volumes:
-    - ../../:/workspace
-    environment:
-      - CI
-      - TBD_PGBIN=/usr/pgsql-9.4/bin
-      - TBD_INSTALL_RPM
-    command: /workspace/test/legacy/run_tests_docker.sh
-  tests_centos7_pg95:
-    image: dalibo/temboard-agent-func:centos7
-    volumes:
-    - ../../:/workspace
-    environment:
-      - CI
-      - TBD_PGBIN=/usr/pgsql-9.5/bin
-      - TBD_INSTALL_RPM
-    command: /workspace/test/legacy/run_tests_docker.sh
-  tests_centos7_pg96:
-    image: dalibo/temboard-agent-func:centos7
-    volumes:
-    - ../../:/workspace
-    environment:
-      - CI
-      - TBD_PGBIN=/usr/pgsql-9.6/bin
-      - TBD_INSTALL_RPM
-    command: /workspace/test/legacy/run_tests_docker.sh
-  tests_centos7_pg10:
-    image: dalibo/temboard-agent-func:centos7
-    volumes:
-    - ../../:/workspace
-    environment:
-      - CI
-      - TBD_PGBIN=/usr/pgsql-10/bin
+      - TBD_PGBIN=/usr/pgsql-${POSTGRES_VERSION-10}/bin
       - TBD_INSTALL_RPM
     command: /workspace/test/legacy/run_tests_docker.sh

--- a/test/legacy/run_tests_docker.sh
+++ b/test/legacy/run_tests_docker.sh
@@ -15,7 +15,7 @@ teardown() {
     # If not on CI and we are docker entrypoint (PID 1), let's wait forever on
     # error. This allows user to enter the container and debug after a build
     # failure.
-    if [ -z "${CI-}" -a $$ = 1 -a $exit_code -gt 0 ] ; then
+    if [ -z "${CI-}" -a $PPID = 1 -a $exit_code -gt 0 ] ; then
         tail -f /dev/null
     fi
 }

--- a/test/legacy/run_tests_docker.sh
+++ b/test/legacy/run_tests_docker.sh
@@ -39,4 +39,4 @@ fi
 
 # Remove any .pyc file to avoid errors with pytest and cache
 find . -name \*.pyc -delete
-TBD_WORKPATH="/tmp" sudo -Eu testuser pytest -vs -p no:cacheprovider test/legacy/
+make -C test/legacy pytest


### PR DESCRIPTION
- don't use machine
- don't clone submodule, we use rpm
- don't build the same docker image
- don't fetch docker-compose
- don't run all tests in the same job
- don't test pg10 twice
- test rpm code instead of git code
