### PR TITLE
Scan for new distributions before loading plugins

### DIFF
--- a/temboardagent/cli.py
+++ b/temboardagent/cli.py
@@ -7,12 +7,22 @@ from glob import glob
 import logging
 import os
 import pdb
+from site import main as refresh_pythonpath
 import sys
 
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
+try:
+    from pkg_resources import (
+        _initialize_master_working_set as refresh_distributions
+    )
+except ImportError:
+    def refresh_distributions():
+        logger.warn("setuptools is too old. Can't reload installed packages.")
+        logger.warn("Restart temboard-agent if you it can't find new plugins.")
 
 from .postgres import Postgres
 from .log import setup_logging
@@ -208,6 +218,10 @@ class Application(object):
             n for n in ng_plugins
             if n not in self.plugins
         ]
+
+        # Refresh sys.path and working_set to ensure new code is loadable.
+        refresh_pythonpath()
+        refresh_distributions()
 
         for name in unloaded_names:
             cls = self.fetch_plugin(name)

--- a/temboardagent/cli.py
+++ b/temboardagent/cli.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from argparse import Action as ArgAction
-from pkg_resources import iter_entry_points
+import pkg_resources
 from distutils.util import strtobool
 from glob import glob
 import logging
@@ -185,7 +185,7 @@ class Application(object):
 
     def fetch_plugin(self, name):
         logger.debug("Looking for plugin %s.", name)
-        for ep in iter_entry_points(self.with_plugins, name):
+        for ep in pkg_resources.iter_entry_points(self.with_plugins, name):
             logger.info("Found plugin %s.", ep)
             try:
                 return ep.load()

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -212,7 +212,7 @@ def test_reload(mocker):
 
 
 def test_fetch_plugin(mocker):
-    iter_ep = mocker.patch('temboardagent.cli.iter_entry_points')
+    iter_ep = mocker.patch('temboardagent.cli.pkg_resources.iter_entry_points')
     from temboardagent.cli import Application
 
     app = Application()
@@ -225,7 +225,7 @@ def test_fetch_plugin(mocker):
 
 
 def test_fetch_failing(mocker):
-    iter_ep = mocker.patch('temboardagent.cli.iter_entry_points')
+    iter_ep = mocker.patch('temboardagent.cli.pkg_resources.iter_entry_points')
     from temboardagent.cli import Application, UserError
 
     app = Application()
@@ -238,7 +238,7 @@ def test_fetch_failing(mocker):
 
 
 def test_fetch_missing(mocker):
-    iter_ep = mocker.patch('temboardagent.cli.iter_entry_points')
+    iter_ep = mocker.patch('temboardagent.cli.pkg_resources.iter_entry_points')
     from temboardagent.cli import Application, UserError
 
     app = Application()

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -249,8 +249,10 @@ def test_fetch_missing(mocker):
 
 
 def test_create_plugins(mocker):
-    mocker.patch(
-        'temboardagent.cli.Application.fetch_plugin', autospec=True)
+    mod = 'temboardagent.cli'
+    mocker.patch(mod + '.refresh_distributions')
+    mocker.patch(mod + '.refresh_pythonpath')
+    mocker.patch(mod + '.Application.fetch_plugin', autospec=True)
     from temboardagent.cli import Application
 
     app = Application()


### PR DESCRIPTION
cf. #131 

This allows to install a plugin after temboard-agent is started, and still activating it with `SIGHUP`.