### PR TITLE
Don't use wal_segment_size as unit for wal_size

### DIFF
--- a/temboardagent/plugins/pgconf/functions.py
+++ b/temboardagent/plugins/pgconf/functions.py
@@ -125,9 +125,7 @@ def get_settings(conn, http_context=None):
                        " OR extra_desc ILIKE '%{0}%'".format(filter)
     query = """
 SELECT
-    name, setting, current_setting(name) AS current_setting,
-    CASE WHEN name IN ('max_wal_size', 'min_wal_size')
-    THEN current_setting('wal_segment_size') ELSE unit END AS unit,
+    name, setting, current_setting(name) AS current_setting, unit,
     vartype, min_val, max_val, enumvals, context, category,
     short_desc||' '||coalesce(extra_desc, '') AS desc, boot_val
 FROM pg_settings


### PR DESCRIPTION
Fixes #238 

Currently in temBoard we rely on the setting units to tell whether the setting has changed and needs reload. For the `min_wal_size` or `max_wal_size`, the unit was retrieved using `current_setting('wal_segment_size')`.
`wal_segment_size` doesn't seem to differ from one version of postgres to an other. However, the `unit` has changed in recent versions. It's "16MB" in versions prior or equal to 9.6, whereas it's "MB" for earlier version.
Things may have change with this commit:
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=9a3215026bd6955e88bd8c20542cfe6acffdb1c8

It seems more reliable to use the `unit` value given in `pg_settings` even for WAL sizes.

This fixes the issue with temBoard being confused when the value hasn't really changed.

See https://github.com/dalibo/temboard/commit/e3050c507142bfd4c512ae0badb4349a67948e87