### PR TITLE
Docker - Call pg_ctl to reload/restart instance

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ CMD ["temboard-agent"]
 
 ADD sudoers /etc/sudoers.d/temboard-agent
 ADD entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ADD pg_ctl_temboard.sh /usr/local/bin/pg_ctl_temboard.sh
 RUN git clone --depth=1 --recursive https://github.com/dalibo/temboard-agent /tmp/temboard-agent && \
     pip install --no-cache-dir /tmp/temboard-agent && \
     rm -rf /tmp/temboard-agent

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -82,7 +82,7 @@ EOF
 
 cat > /etc/temboard-agent/temboard-agent.conf.d/administration.conf << EOF
 [administration]
-pg_ctl = docker %s ${PGCONTAINER}
+pg_ctl = /usr/local/bin/pg_ctl_temboard.sh ${PGCONTAINER} %s
 EOF
 
 touch /etc/temboard-agent/users

--- a/docker/pg_ctl_temboard.sh
+++ b/docker/pg_ctl_temboard.sh
@@ -1,0 +1,13 @@
+#! /bin/bash -eu
+
+PGCONTAINER=$1
+COMMAND=$2
+
+case $COMMAND in
+	start|stop|restart)
+		docker $COMMAND $PGCONTAINER
+		;;
+	*)
+		docker exec $PGCONTAINER su postgres -c "/usr/local/bin/pg_ctl $COMMAND"
+		;;
+esac


### PR DESCRIPTION
Fixes https://github.com/dalibo/temboard/issues/397

While it works for `restart` or `stop`, the `docker` command doesn't have any `reload` command.