### PR TITLE
Find pg_ctl in path

### DIFF
--- a/docker/pg_ctl_temboard.sh
+++ b/docker/pg_ctl_temboard.sh
@@ -8,6 +8,6 @@ case $COMMAND in
 		docker $COMMAND $PGCONTAINER
 		;;
 	*)
-		docker exec $PGCONTAINER su postgres -c "/usr/local/bin/pg_ctl $COMMAND"
+		docker exec $PGCONTAINER sh -c "SU_PATH=\$PATH su -m postgres -c \"PATH=\$PATH:\$SU_PATH; pg_ctl $COMMAND\""
 		;;
 esac


### PR DESCRIPTION
"/usr/local/bin" is not a universal path for pg_ctl.
For the postgres:9.6 docker image, it is available in "/usr/lib/postgresql/9.6/bin/".
This path is in root's PATH. I change the script to use.
It may look a bit ugly, but this is the only workaround I found.

Fixes https://github.com/dalibo/temboard/issues/272