### PR TITLE
Authentication by key

### DIFF
--- a/doc/core_api.rst
+++ b/doc/core_api.rst
@@ -204,6 +204,7 @@ Core API
 
     Get all notifications from the agent.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session ID

--- a/doc/dashboard_api.rst
+++ b/doc/dashboard_api.rst
@@ -7,6 +7,7 @@ Dashboard plugin API
 
     Get the whole last data set used to render dashboard view. Data have been collected async.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -97,6 +98,7 @@ Dashboard plugin API
 
     Get the dashboard plugin config.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -156,6 +158,7 @@ Dashboard plugin API
 
     Get the last ``n`` sets of dashboard data. ``n`` is defined by parameter ``history_length`` from the ``dashboard`` section of configuration file. Default value is ``150``.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -233,6 +236,7 @@ Dashboard plugin API
 
     Get the number of buffers allocated by PostgreSQL ``background writer`` process.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -263,6 +267,7 @@ Dashboard plugin API
 
     Get PostgreSQL global cache hit ratio.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -293,6 +298,7 @@ Dashboard plugin API
 
     Get the total number of active backends.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -329,6 +335,7 @@ Dashboard plugin API
 
     Get CPU usage.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -368,6 +375,7 @@ Dashboard plugin API
 
     System loadaverage.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -400,6 +408,7 @@ Dashboard plugin API
 
     Memory usage.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -438,6 +447,7 @@ Dashboard plugin API
 
     Machine hostname.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -470,6 +480,7 @@ Dashboard plugin API
 
     Operating system version.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -502,6 +513,7 @@ Dashboard plugin API
 
     Get PostgreSQL server version.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -534,6 +546,7 @@ Dashboard plugin API
 
     Number of CPU.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -566,6 +579,7 @@ Dashboard plugin API
 
     PostgreSQL cluster size & number of databases.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -606,6 +620,7 @@ Dashboard plugin API
 
     Get a bunch of global informations about system and PostgreSQL.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -643,6 +658,7 @@ Dashboard plugin API
 
     Get the max_connections settings value.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session

--- a/doc/monitoring_api.rst
+++ b/doc/monitoring_api.rst
@@ -7,6 +7,7 @@ Monitoring plugin API
 
     Run ``sessions`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -78,6 +79,7 @@ Monitoring plugin API
 
     Run ``xacts`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -121,6 +123,7 @@ Monitoring plugin API
 
     Run ``locks`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -178,6 +181,7 @@ Monitoring plugin API
 
     Run ``blocks`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -222,6 +226,7 @@ Monitoring plugin API
 
     Run ``bgwriter`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -273,6 +278,7 @@ Monitoring plugin API
 
     Run ``db_size`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -321,6 +327,7 @@ Monitoring plugin API
 
     Run ``tblspc_size`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -375,6 +382,7 @@ Monitoring plugin API
 
     Run ``filesystems_size`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -425,6 +433,7 @@ Monitoring plugin API
 
     Run ``cpu`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -501,6 +510,7 @@ Monitoring plugin API
 
     Run ``process`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -546,6 +556,7 @@ Monitoring plugin API
 
     Run ``memory`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session
@@ -592,6 +603,7 @@ Monitoring plugin API
 
     Run ``loadavg`` monitoring probe.
 
+    :query key: Agent's key for authentication (optional)
     :reqheader X-Session: Session ID
     :status 200: no error
     :status 401: invalid session

--- a/temboardagent/api.py
+++ b/temboardagent/api.py
@@ -148,7 +148,7 @@ def profile(http_context, app, sessions):
         raise HTTPError(401, "Invalid session.")
 
 
-@add_route('GET', b'/notifications')
+@add_route('GET', b'/notifications', check_key=True)
 def notifications(http_context, app, sessions):
     logger.info("Get notifications.")
     try:

--- a/temboardagent/plugins/dashboard/__init__.py
+++ b/temboardagent/plugins/dashboard/__init__.py
@@ -16,12 +16,12 @@ routes = RouteSet(prefix=b'/dashboard')
 workers = taskmanager.WorkerSet()
 
 
-@routes.get(b'')
+@routes.get(b'', check_key=True)
 def dashboard(http_context, app):
     return metrics.get_metrics_queue(app.config)
 
 
-@routes.get(b'/config')
+@routes.get(b'/config', check_key=True)
 def dashboard_config(http_context, app):
     return dict(
         scheduler_interval=app.config.dashboard.scheduler_interval,
@@ -29,84 +29,84 @@ def dashboard_config(http_context, app):
     )
 
 
-@routes.get(b'/live')
+@routes.get(b'/live', check_key=True)
 def dashboard_live(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_metrics(conn, app.config)
 
 
-@routes.get(b'/history')
+@routes.get(b'/history', check_key=True)
 def dashboard_history(http_context, app):
     return metrics.get_history_metrics_queue(app.config)
 
 
-@routes.get(b'/buffers')
+@routes.get(b'/buffers', check_key=True)
 def dashboard_buffers(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_buffers(conn)
 
 
-@routes.get(b'/hitratio')
+@routes.get(b'/hitratio', check_key=True)
 def dashboard_hitratio(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_hitratio(conn)
 
 
-@routes.get(b'/active_backends')
+@routes.get(b'/active_backends', check_key=True)
 def dashboard_active_backends(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_active_backends(conn)
 
 
-@routes.get(b'/cpu')
+@routes.get(b'/cpu', check_key=True)
 def dashboard_cpu(http_context, app):
     return metrics.get_cpu_usage()
 
 
-@routes.get(b'/loadaverage')
+@routes.get(b'/loadaverage', check_key=True)
 def dashboard_loadaverage(http_context, app):
     return metrics.get_loadaverage()
 
 
-@routes.get(b'/memory')
+@routes.get(b'/memory', check_key=True)
 def dashboard_memory(http_context, app):
     return metrics.get_memory_usage()
 
 
-@routes.get(b'/hostname')
+@routes.get(b'/hostname', check_key=True)
 def dashboard_hostname(http_context, app):
     return metrics.get_hostname(app.config)
 
 
-@routes.get(b'/os_version')
+@routes.get(b'/os_version', check_key=True)
 def dashboard_os_version(http_context, app):
     return metrics.get_os_version()
 
 
-@routes.get(b'/pg_version')
+@routes.get(b'/pg_version', check_key=True)
 def dashboard_pg_version(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_pg_version(conn)
 
 
-@routes.get(b'/n_cpu')
+@routes.get(b'/n_cpu', check_key=True)
 def dashboard_n_cpu(http_context, app):
     return metrics.get_n_cpu()
 
 
-@routes.get(b'/databases')
+@routes.get(b'/databases', check_key=True)
 def dashboard_databases(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_databases(conn)
 
 
-@routes.get(b'/info')
+@routes.get(b'/info', check_key=True)
 def dashboard_info(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_info(conn, app.config)
 
 
-@routes.get(b'/max_connections')
+@routes.get(b'/max_connections', check_key=True)
 def dashboard_max_connections(http_context, app):
     with app.postgres.connect() as conn:
         return metrics.get_max_connections(conn)

--- a/temboardagent/plugins/monitoring/__init__.py
+++ b/temboardagent/plugins/monitoring/__init__.py
@@ -43,73 +43,73 @@ workers = taskmanager.WorkerSet()
 routes = RouteSet(prefix=b'/monitoring/probe')
 
 
-@routes.get(b'/sessions')
+@routes.get(b'/sessions', check_key=True)
 def get_probe_sessions(http_context, app):
     return api_run_probe(probe_sessions(app.config.monitoring), app.config)
 
 
-@routes.get(b'/xacts')
+@routes.get(b'/xacts', check_key=True)
 def get_probe_xacts(http_context, app):
     return api_run_probe(probe_xacts(app.config.monitoring), app.config)
 
 
-@routes.get(b'/locks')
+@routes.get(b'/locks', check_key=True)
 def get_probe_locks(http_context, app):
     return api_run_probe(probe_locks(app.config.monitoring), app.config)
 
 
-@routes.get(b'/blocks')
+@routes.get(b'/blocks', check_key=True)
 def get_probe_blocks(http_context, app):
     return api_run_probe(probe_blocks(app.config.monitoring), app.config)
 
 
-@routes.get(b'/bgwriter')
+@routes.get(b'/bgwriter', check_key=True)
 def get_probe_bgwriter(http_context, app):
     return api_run_probe(probe_bgwriter(app.config.monitoring), app.config)
 
 
-@routes.get(b'/db_size')
+@routes.get(b'/db_size', check_key=True)
 def get_probe_db_size(http_context, app):
     return api_run_probe(probe_db_size(app.config.monitoring), app.config)
 
 
-@routes.get(b'/tblspc_size')
+@routes.get(b'/tblspc_size', check_key=True)
 def get_probe_tblspc_size(http_context, app):
     return api_run_probe(probe_tblspc_size(app.config.monitoring), app.config)
 
 
-@routes.get(b'/filesystems_size')
+@routes.get(b'/filesystems_size', check_key=True)
 def get_probe_filesystems_size(http_context, app):
     return api_run_probe(probe_filesystems_size(app.config.monitoring),
                          app.config)
 
 
-@routes.get(b'/cpu')
+@routes.get(b'/cpu', check_key=True)
 def get_probe_cpu(http_context, app):
     return api_run_probe(probe_cpu(app.config.monitoring), app.config)
 
 
-@routes.get(b'/process')
+@routes.get(b'/process', check_key=True)
 def get_probe_process(http_context, app):
     return api_run_probe(probe_process(app.config.monitoring), app.config)
 
 
-@routes.get(b'/memory')
+@routes.get(b'/memory', check_key=True)
 def get_probe_memory(http_context, app):
     return api_run_probe(probe_memory(app.config.monitoring), app.config)
 
 
-@routes.get(b'/loadavg')
+@routes.get(b'/loadavg', check_key=True)
 def get_probe_loadavg(http_context, app):
     return api_run_probe(probe_loadavg(app.config.monitoring), app.config)
 
 
-@routes.get(b'/wal_files')
+@routes.get(b'/wal_files', check_key=True)
 def get_probe_wal_files(http_context, app):
     return api_run_probe(probe_wal_files(app.config.monitoring), app.config)
 
 
-@routes.get(b'/replication')
+@routes.get(b'/replication', check_key=True)
 def get_probe_replication(http_context, app):
     return api_run_probe(probe_replication(app.config.monitoring), app.config)
 

--- a/temboardagent/routing.py
+++ b/temboardagent/routing.py
@@ -7,7 +7,7 @@ WORKERS = []
 logger = logging.getLogger(__name__)
 
 
-def make_route(function, method, path, check_session):
+def make_route(function, method, path, check_session, check_key):
     splitpath = []
     elts = path.split(b'/')
     pos = 0
@@ -41,16 +41,18 @@ def make_route(function, method, path, check_session):
         module=function.__module__,
         function=function.__name__,
         check_session=check_session,
+        check_key=check_key,
     )
 
 
-def add_route(method, path, check_session=True):
+def add_route(method, path, check_session=True, check_key=False):
     """
     Function decorator for HTTP method/path -> API function mapping.
     """
     def func_wrapper(function):
         global ROUTES
-        ROUTES.append(make_route(function, method, path, check_session))
+        ROUTES.append(make_route(function, method, path, check_session,
+                                 check_key))
         return function
     return func_wrapper
 
@@ -82,23 +84,26 @@ class RouteSet(list):
     def __init__(self, prefix=b''):
         self.prefix = prefix
 
-    def delete(self, path, check_session=True):
+    def delete(self, path, check_session=True, check_key=False):
         def register_route(f):
             self.append(
-                make_route(f, 'DELETE', self.prefix + path, check_session))
+                make_route(f, 'DELETE', self.prefix + path, check_session,
+                           check_key))
             return f
         return register_route
 
-    def get(self, path, check_session=True):
+    def get(self, path, check_session=True, check_key=False):
         def register_route(f):
             self.append(
-                make_route(f, 'GET', self.prefix + path, check_session))
+                make_route(f, 'GET', self.prefix + path, check_session,
+                           check_key))
             return f
         return register_route
 
-    def post(self, path, check_session=True):
+    def post(self, path, check_session=True, check_key=False):
         def register_route(f):
             self.append(
-                make_route(f, 'POST', self.prefix + path, check_session))
+                make_route(f, 'POST', self.prefix + path, check_session,
+                           check_key))
             return f
         return register_route


### PR DESCRIPTION
This PR introduces a new way to protect access to some non-sensitives APIs.
Clients can now get access to dashboard and monitoring APIs without being authenticated with usual credentials: the agent key (the one configured in `temboard-agent.conf` file) can now be passed in query URL like `GET /dashboard?key=MYSECRETKEY`. In this case, `X-Session` header is not mandatory anymore. If the key is not configured in configuration file, then this authentication method is not allowed.