### PR TITLE
Stopped postgres

### DIFF
--- a/temboardagent/httpd.py
+++ b/temboardagent/httpd.py
@@ -112,6 +112,12 @@ class RequestHandler(BaseHTTPRequestHandler):
             logger.error(e.message)
             code = e.code
             message = e.message
+        except UserError as e:
+            msg = str(e)
+            logger.exception(msg)
+            logger.error(msg)
+            code = 500
+            message = {'error': msg}
         except Exception as e:
             logger.exception(str(e))
             logger.error("Internal error")

--- a/temboardagent/plugins/dashboard/__init__.py
+++ b/temboardagent/plugins/dashboard/__init__.py
@@ -31,8 +31,7 @@ def dashboard_config(http_context, app):
 
 @routes.get(b'/live', check_key=True)
 def dashboard_live(http_context, app):
-    with app.postgres.connect() as conn:
-        return metrics.get_metrics(conn, app.config)
+    return metrics.get_metrics(app)
 
 
 @routes.get(b'/history', check_key=True)
@@ -115,8 +114,7 @@ def dashboard_max_connections(http_context, app):
 @workers.register(pool_size=1)
 def dashboard_collector_worker(app):
     logger.debug("Starting to collect dashboard data")
-    with app.postgres.connect() as conn:
-        data = metrics.get_metrics(conn, app.config)
+    data = metrics.get_metrics(app)
 
     # We don't want to store notifications in the history.
     data.pop('notifications', None)

--- a/temboardagent/postgres.py
+++ b/temboardagent/postgres.py
@@ -22,7 +22,7 @@ class ConnectionManager(object):
         try:
             self.conn.connect()
         except PostgresError as e:
-            raise UserError("Failed to connect to Postgres: %s" % (e,))
+            raise UserError("Failed to connect to Postgres")
         return self.conn
 
     def __exit__(self, *a):


### PR DESCRIPTION
With this PR, we:
 - make sure that the agent continues to send metrics to the UI collector even if not connexion to Postgres is possible. In this case, only system metrics are sent with a global datetime.
 - send the error message if any for http requests.