### PR TITLE
Fix PG backend error handler

### DIFF
--- a/temboardagent/spc.py
+++ b/temboardagent/spc.py
@@ -694,10 +694,10 @@ class connector(object):
             msg = 'PostgreSQL backend error.'
             if message[1] is not None:
                 err_string = message[1]['string']
-                err_split = err_string.split('\x00')
-                msg = err_split[2][1:].decode()
+                err_split = err_string.split(b'\x00')
+                msg = err_split[3][1:].decode()
                 typ = err_split[0][0:].decode()
-                code = err_split[1][1:].decode()
+                code = err_split[2][1:].decode()
 
             raise error(code, typ, msg)
 


### PR DESCRIPTION
Before the patch, the error message displayed in the logs was actually an erro code.

With the patch, we now correctly display the message.

Here what message[1] was in my case:
``` python
{'type': 'S', 'string': b'ERROR\x00VERROR\x00C42P01\x00Mrelation "pg_catalog.tables" does not exist\x00P32\x00Fparse_relation.c\x00L1159\x00RparserOpenTable\
x00\x00'}
```

Could this change between different versions of PostgreSQL?