### PR TITLE
Revert "rpm: Install global temboard-agent.conf only on RHEL6"

### DIFF
--- a/packaging/rpm/temboard-agent.spec
+++ b/packaging/rpm/temboard-agent.spec
@@ -50,10 +50,10 @@ PATH=$PATH:%{buildroot}%{python_sitelib}/%{pkgname}
 # config file
 %{__install} -d -m 755 %{buildroot}/%{_sysconfdir}
 %{__install} -d -m 750 %{buildroot}/%{_sysconfdir}/temboard-agent
+%{__install} -m 600 %{SOURCE3} %{buildroot}/%{_sysconfdir}/temboard-agent/temboard-agent.conf
 
 # init script
 %if 0%{?rhel} <= 6
-%{__install} -m 600 %{SOURCE3} %{buildroot}/%{_sysconfdir}/temboard-agent/temboard-agent.conf
 %{__install} -d %{buildroot}%{_initrddir}
 %{__install} -m 755 %{SOURCE1} %{buildroot}%{_initrddir}/temboard-agent
 rm -f %{buildroot}/usr/lib/systemd/system/temboard-agent*.service


### PR DESCRIPTION
This reverts commit acf0bb46b3386d912cf119b3ea96a277558d2490.