### PR TITLE
Docker fixes and updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,7 @@ RUN apt-get update -y \
     ;
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/local/bin/wait-for-it
-
-RUN chmod 0755 /usr/local/bin/wait-for-it \
-    && groupadd --system docker \
-    && useradd --home-dir /var/lib/postgresql --create-home --system --groups docker postgres
+RUN chmod 0755 /usr/local/bin/wait-for-it
 
 VOLUME /var/lib/temboard-agent
 WORKDIR /var/lib/temboard-agent

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 RUN apt-get update -y \
     && mkdir -p /usr/share/man/man1 /usr/share/man/man7 \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 NAME="dalibo/temboard-agent"
 
 build:
-	docker build --tag $(NAME) .
+	docker build --build-arg http_proxy --tag $(NAME) .
 
 clean:
 	docker images --quiet $(NAME) | xargs --no-run-if-empty --verbose docker rmi -f

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,12 @@
+# This file mounts local docker-entrypoint to use it in agent container.
+#
+# Use it by exporting
+# COMPOSE_FILE=docker-compose.yml:docker/docker-compose.dev.yml and run
+# docker-compose as usual.
+
 version: '2'
 
 services:
   agent:
     volumes:
-      - ./docker/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+    - ./docker/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
I hit a bug in user management with different combination of docker uid.

Fixes:

```
agent_1       | + groupmod -g 998 docker
agent_1       | groupmod: group 'docker' does not exist
agent_1       | + catchall
agent_1       | + '[' 0 -lt 2 -a 6 -gt 0 ']'
agent_1       | + tail -f /dev/null
```