### PR TITLE
Fix #328 - backport v3

### DIFF
--- a/temboardagent/postgres.py
+++ b/temboardagent/postgres.py
@@ -21,8 +21,8 @@ class ConnectionManager(object):
         )
         try:
             self.conn.connect()
-        except PostgresError:
-            raise UserError("Failed to connect to Postgres")
+        except PostgresError as e:
+            raise UserError("Failed to connect to Postgres: %s" % e.message)
         return self.conn
 
     def __exit__(self, *a):

--- a/temboardagent/spc.py
+++ b/temboardagent/spc.py
@@ -821,6 +821,8 @@ class connector(object):
                         "Authentication method not supported")
 
         if self._protocol.is_auth_md5(messages[0]):
+            if not self._password:
+                raise error('PGC108', 'FATAL', "No password supplied")
             # MD5
             password = "md5" + hashlib.md5(
                 hashlib.md5(


### PR DESCRIPTION
SPC should raise an error if no password supplied with md5 auth. method