### PR TITLE
Manage hyphen in cluster name

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,7 @@ In order to run temBoard agent, you require:
 - openssl.
 - Python 2.6+ or 3.5+. Check with ``python --version``.
 - A running temBoard UI.
-- bash and sudo for setup script.
+- bash, curl and sudo for setup script.
 
 
 Now choose the method matching best your target environment.

--- a/packaging/temboard-agent@.service
+++ b/packaging/temboard-agent@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=PostgreSQL Remote Control Agent %I
 After=network.target postgresql@%i.service
+AssertPathExists=/etc/temboard-agent/%I/temboard-agent.conf
 
 [Service]
 Type=simple

--- a/share/auto_configure.sh
+++ b/share/auto_configure.sh
@@ -230,7 +230,8 @@ generate_configuration $home "${sslfiles[@]}" $key $name $logfile $collector_url
 
 # systemd
 if [ -x /bin/systemctl ] ; then
-	unit=temboard-agent@${name//\//-}.service
+	template=$(systemd-escape ${name})
+	unit=temboard-agent@${template}.service
 	systemctl enable $unit
 	log "Enabling systemd unit ${unit}."
 	start_cmd="systemctl start $unit"

--- a/share/auto_configure.sh
+++ b/share/auto_configure.sh
@@ -240,7 +240,7 @@ else
 fi
 
 log
-log "Success. You can now start temboard--agent using:"
+log "Success. You can now start temboard-agent using:"
 log
 log "    ${start_cmd}"
 log


### PR DESCRIPTION
Should fix #355 

Hyphen has a meaning in systemd unit. It is translated to `/`. There is a way to escape hyphen, let's use it.

Note that debian management scripts does not handle this well.