### PR TITLE
Natural increment of autoconfigured port

### DIFF
--- a/share/auto_configure.sh
+++ b/share/auto_configure.sh
@@ -56,7 +56,7 @@ generate_configuration() {
 	local logfile=$1; shift
 	local collector_url=$1; shift
 
-	local port=$(echo $PGPORT | rev)
+	local port=${TEMBOARD_PORT-$(rev <<< $PGPORT)}
 	log "Configuring temboard-agent to run on port ${port}."
 	local pg_ctl=$(which pg_ctl)
 


### PR DESCRIPTION
``` console
root@temboard:/# PGHOST=/var/run/postgresql/ PGPORT=5433 /usr/local/src/dalibo/temboard-agent-dev/share/auto_configure.sh https://ui.tba.docker:8888
...
Configuring temboard-agent to run on port 2346.
...
$
```