### PR TITLE
Install docker.io in Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
       - run:/var/run/postgresql/:ro
-      - /usr/bin/docker:/usr/bin/docker:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/usr/local/src/temboard-agent/
     links:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y \
         postgresql-client \
         sudo \
         git-core \
+        docker.io \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     ;


### PR DESCRIPTION
This way, we do not need to mount the "docker" binary from host to the
container.

This is essentially needed to make things work from temboard's docker
environment when using the docker.io package (on host) from Debian
instead of docker-ce from docker.com repository. See also respective
commit in temboard repository.