### PR TITLE
Return username and dbname in statements plugin API

### DIFF
--- a/docs/statements_api.rst
+++ b/docs/statements_api.rst
@@ -27,8 +27,10 @@ Statements plugin API
       "snapshot_datetime": "2020-03-17 17:31:25.0929+01",
       "data": [
         {
-          "username": "postgres",
-          "dbname ": "bench",
+          "rolname": "postgres",
+          "datname ": "bench",
+          "userid": 987342,
+          "dbid": 8737,
           "queryid": 125206108,
           "query": "SELECT pg_sleep($1)",
           "calls": 1,

--- a/temboardagent/plugins/statements/__init__.py
+++ b/temboardagent/plugins/statements/__init__.py
@@ -11,6 +11,17 @@ logger = logging.getLogger(__name__)
 routes = RouteSet(prefix=b"/statements")
 
 
+query = """\
+SELECT
+  rolname,
+  datname,
+  pg_stat_statements.*
+FROM pg_stat_statements
+JOIN pg_authid ON pg_stat_statements.userid = pg_authid.oid
+JOIN pg_database ON pg_stat_statements.dbid = pg_database.oid
+"""
+
+
 @routes.get(b"/", check_key=True)
 def get_statements(http_context, app):
     """Return a snapshot of latest statistics of executed SQL statements and
@@ -29,7 +40,7 @@ def get_statements(http_context, app):
     snapshot_datetime = now()
     try:
         conn.connect()
-        conn.execute("SELECT * FROM pg_stat_statements")
+        conn.execute(query)
         data = list(conn.get_rows())
         conn.execute("SELECT pg_stat_statements_reset()")
     except error as e:

--- a/tests/func/test_statements.py
+++ b/tests/func/test_statements.py
@@ -106,6 +106,7 @@ def test_statements(xsession, extension_enabled):
             u"blk_read_time",
             u"blk_write_time",
             u"calls",
+            u"datname",
             u"dbid",
             u"local_blks_dirtied",
             u"local_blks_hit",
@@ -116,6 +117,7 @@ def test_statements(xsession, extension_enabled):
             u"min_time",
             u"query",
             u"queryid",
+            u"rolname",
             u"rows",
             u"shared_blks_dirtied",
             u"shared_blks_hit",
@@ -129,6 +131,8 @@ def test_statements(xsession, extension_enabled):
         ]
     )
     assert all(set(d) == expected_keys for d in data)
+    assert "temboard" in set([d["rolname"] for d in data])
+    assert "postgres" in set([d["datname"] for d in data])
     queries = [d["query"] for d in data]
     assert "CREATE EXTENSION pg_stat_statements" in queries
 
@@ -147,6 +151,8 @@ def test_statements(xsession, extension_enabled):
     assert new_data
     assert all(set(d) == expected_keys for d in new_data)
     assert len(new_data) != len(data)
+    assert "temboard" in set([d["rolname"] for d in new_data])
+    assert "postgres" in set([d["datname"] for d in new_data])
     new_queries = [d["query"] for d in new_data]
     assert "SELECT pg_stat_statements_reset()" in new_queries
     if pg_version > (10,):


### PR DESCRIPTION
Instead of returning the dbid and userid, we now return database name
and user name by joining the pg_stat_statements table on pg_authid and
pg_database.