### PR TITLE
Support changes in types for some settings in PG12 (int -> real)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,13 @@ jobs:
          - dist/*.deb
 
   # Please keep tests/func/Makefile run-all test matrix sync with the following.
+  1-func-centos7-pg12:
+    docker:
+    - image: dalibo/temboard-agent-sdk:centos7
+      environment:
+        TBD_PGBIN: /usr/pgsql-12/bin
+    <<: *func-job
+
   1-func-centos7-pg11:
     docker:
     - image: dalibo/temboard-agent-sdk:centos7

--- a/temboardagent/plugins/pgconf/functions.py
+++ b/temboardagent/plugins/pgconf/functions.py
@@ -231,6 +231,10 @@ def post_settings(conn, config, http_context):
                                 setting['setting'] = None
                             checked = True
                         if item['vartype'] == u'real':
+                            setting['setting'] \
+                                = human_to_number(setting['setting'],
+                                                  item['unit'],
+                                                  float)
                             # Real handling.
                             if item['min_val'] and \
                                (float(setting['setting']) <
@@ -242,7 +246,6 @@ def post_settings(conn, config, http_context):
                                    float(item['max_val'])):
                                 raise HTTPError(406, "%s: Invalid setting." %
                                                      (item['name']))
-                            setting['setting'] = float(setting['setting'])
                             checked = True
                         if item['vartype'] == u'bool':
                             # Boolean handling.

--- a/temboardagent/plugins/pgconf/functions.py
+++ b/temboardagent/plugins/pgconf/functions.py
@@ -113,7 +113,7 @@ FROM pg_settings
     return ret
 
 
-def human_to_number(h_value, h_unit=None):
+def human_to_number(h_value, h_unit=None, h_type=int):
     units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'YB', 'ZB']
     re_unit = re.compile(r'([0-9.]+)\s*([KMGBTPEYZ]?B)$', re.IGNORECASE)
     m_value = re_unit.match(str(h_value))
@@ -157,9 +157,9 @@ def human_to_number(h_value, h_unit=None):
         p_num = m_unit.group(1)
         p_unit = m_unit.group(2)
         if mult[p_unit] > 0:
-            return (int(p_num) * mult[p_unit])
+            return (h_type(p_num) * mult[p_unit])
         else:
-            return (int(p_num) / abs(mult[p_unit]))
+            return (h_type(p_num) / abs(mult[p_unit]))
 
     return h_value
 

--- a/temboardagent/plugins/pgconf/functions.py
+++ b/temboardagent/plugins/pgconf/functions.py
@@ -138,10 +138,11 @@ def human_to_number(h_value, h_unit=None, h_type=int):
 
     # Valid time units are ms (milliseconds), s (seconds), min (minutes),
     # h (hours), and d (days
-    re_unit = re.compile(r'([0-9.]+)\s*(ms|s|min|h|d)$')
+    re_unit = re.compile(r'([0-9.]+)\s*(us|ms|s|min|h|d)$')
     m_unit = re_unit.match(str(h_value))
     if h_unit == 'ms':
-        mult = {'ms': 1, 's': 1000, 'min': 60000, 'h': 3600000, 'd': 86400000}
+        mult = {'us': 0.001, 'ms': 1, 's': 1000, 'min': 60000, 'h': 3600000,
+                'd': 86400000}
     elif h_unit == 's':
         mult = {'ms': -1000, 's': 1, 'min': 60, 'h': 3600, 'd': 86400}
     elif h_unit == 'min':

--- a/tests/func/Makefile
+++ b/tests/func/Makefile
@@ -15,4 +15,4 @@ shell:
 
 PYTEST_ARGS?=
 pytest:
-	TBD_WORKPATH="/tmp" sudo -Eu testuser pytest -vs -p no:cacheprovider ./ $(PYTEST_ARGS)
+	TBD_WORKPATH="/tmp" sudo -Eu testuser pytest -vs -p no:cacheprovider $(PYTEST_ARGS)

--- a/tests/func/Makefile
+++ b/tests/func/Makefile
@@ -5,6 +5,7 @@ run:
 
 run-all:
 	$(MAKE) run
+	TAG=centos7 POSTGRES_VERSION=11 $(MAKE) run
 	TAG=centos7 POSTGRES_VERSION=10 $(MAKE) run
 	TAG=centos7 POSTGRES_VERSION=9.6 $(MAKE) run
 	TAG=centos6 POSTGRES_VERSION=9.5 $(MAKE) run

--- a/tests/func/docker-compose.yml
+++ b/tests/func/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     - ../../:/workspace
     environment:
       - CI
-      - TBD_PGBIN=/usr/pgsql-${POSTGRES_VERSION-11}/bin
+      - TBD_PGBIN=/usr/pgsql-${POSTGRES_VERSION-12}/bin
       - TBD_INSTALL_RPM
     command: /workspace/tests/func/run_tests_docker.sh

--- a/tests/func/docker-compose.yml
+++ b/tests/func/docker-compose.yml
@@ -10,4 +10,5 @@ services:
       - TBD_PGVERSION=${POSTGRES_VERSION-12}
       - TBD_PGBIN=/usr/pgsql-${POSTGRES_VERSION-12}/bin
       - TBD_INSTALL_RPM
+      - PYTEST_ARGS
     command: /workspace/tests/func/run_tests_docker.sh

--- a/tests/func/docker-compose.yml
+++ b/tests/func/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     - ../../:/workspace
     environment:
       - CI
+      - TBD_PGVERSION=${POSTGRES_VERSION-12}
       - TBD_PGBIN=/usr/pgsql-${POSTGRES_VERSION-12}/bin
       - TBD_INSTALL_RPM
     command: /workspace/tests/func/run_tests_docker.sh

--- a/tests/func/test/configtest.py
+++ b/tests/func/test/configtest.py
@@ -8,6 +8,7 @@ WORK_PATH = '/tmp'
 # PG_BIN = '/usr/lib/postgresql/9.5/bin'
 # Gentoo / 9.5
 PG_BIN = '/usr/lib64/postgresql-9.5/bin'
+PG_VERSION = '9.5'
 PG_PORT = 5445
 PG_USER = 'temboard'
 PG_PASSWORD = 'temboard'

--- a/tests/func/test/temboard.py
+++ b/tests/func/test/temboard.py
@@ -241,6 +241,10 @@ def build_env_dict():
     tbd_workpath = test_conf.WORK_PATH
     if 'TBD_WORKPATH' in os.environ:
         tbd_workpath = os.environ['TBD_WORKPATH']
+    # PostgreSQL version
+    tbd_pgversion = test_conf.PG_VERSION
+    if 'TBD_PGVERSION' in os.environ:
+        tbd_pgversion = os.environ['TBD_PGVERSION']
 
     test_env = {
         'agent': {
@@ -264,6 +268,7 @@ def build_env_dict():
             'socket_dir': None,
             'port': str(tbd_pgport),
             'user': test_conf.PG_USER,
+            'version': float(tbd_pgversion),
             'password': test_conf.PG_PASSWORD,
             'log_file': None
         }

--- a/tests/unit/test_plugins_pgconf.py
+++ b/tests/unit/test_plugins_pgconf.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def test_human_to_number():
+    from temboardagent.plugins.pgconf.functions import human_to_number
+
+    assert 2 == human_to_number('2ms', 'ms')
+    with pytest.raises(Exception):
+        assert 0.2 == human_to_number('0.2ms', 'ms')
+    assert 0.2 == human_to_number('0.2ms', 'ms', float)
+    assert 2.2 == human_to_number('2200us', 'ms')


### PR DESCRIPTION
See https://github.com/dalibo/temboard/issues/738

In Postgres 12, changes took place for some settings type. For example `autovacuum_vacuum_cost_delay` is now considered as real.
In temBoard we were correctly dealing with values written with a unit (for example '2ms') for settings of type integer. Settings of type real were considered to be written without a unit.
This PR makes sure that values with a unit are taken into account even if the setting is of type real.

At the same time, we need to handle values like '200us' since it is what '0.2ms' is converted to.