### PR TITLE
Switch back Dockerfile to Python 2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:2.7-slim
 
 RUN apt-get update -y \
     && mkdir -p /usr/share/man/man1 /usr/share/man/man7 \

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ SETUP_KWARGS = dict(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Environment :: No Input/Output (Daemon)",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved",


### PR DESCRIPTION
Until we have regression tests on Python3.

Fixes:

    Unhandled error:
    Traceback (most recent call last):
    File "/usr/local/src/temboard-agent/temboardagent/postgres.py", line 22, in __enter__
        self.conn.connect()
    AttributeError: 'psycopg2.extensions.connection' object has no attribute 'connect'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
    File "/usr/local/src/temboard-agent/temboardagent/toolkit/app.py", line 301, in entrypoint
        retcode = self.main(argv, environ)
    File "/usr/local/src/temboard-agent/temboardagent/scripts/agent.py", line 110, in main
        self.apply_config()
    File "/usr/local/src/temboard-agent/temboardagent/cli.py", line 68, in apply_config
        return super(Application, self).apply_config()
    File "/usr/local/src/temboard-agent/temboardagent/toolkit/app.py", line 184, in apply_config
        self.update_plugins(old_plugins=old_plugins)
    File "/usr/local/src/temboard-agent/temboardagent/toolkit/app.py", line 263, in update_plugins
        self.plugins[name].load()
    File "/usr/local/src/temboard-agent/temboardagent/plugins/pgconf/__init__.py", line 45, in load
        pg_version = self.app.postgres.fetch_version()
    File "/usr/local/src/temboard-agent/temboardagent/postgres.py", line 53, in fetch_version
        with self.connect() as conn:
    File "/usr/local/src/temboard-agent/temboardagent/postgres.py", line 24, in __enter__
        raise UserError("Failed to connect to Postgres: %s" % e.message)
    AttributeError: 'AttributeError' object has no attribute 'message'