### PR TITLE
Fix discover test, missing statements plugin

### DIFF
--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -192,4 +192,5 @@ class TestAPI:
             "administration",
             "activity",
             "maintenance",
+            "statements",
         }


### PR DESCRIPTION
This fixes failing tests after adding the statements plugin. See #436 