### PR TITLE
Send the original error message

### DIFF
--- a/temboardagent/plugins/statements/__init__.py
+++ b/temboardagent/plugins/statements/__init__.py
@@ -77,7 +77,7 @@ def get_statements(http_context, app):
             dbname,
             e,
         )
-        raise HTTPError(500, "Internal server error")
+        raise HTTPError(500, e)
     else:
         return {"snapshot_datetime": snapshot_datetime, "data": data}
 


### PR DESCRIPTION
This is helpful in order to know when the extension has not been loaded via preload_libraries.