### PR TITLE
Allow agent to start without postgres

### DIFF
--- a/temboardagent/api.py
+++ b/temboardagent/api.py
@@ -110,7 +110,7 @@ def get_discover(http_context, app, sessions):
         hostname=None,
         cpu=None,
         memory_size=None,
-        pg_port=None,
+        pg_port=app.config.postgresql['port'],
         pg_version=None,
         pg_version_summary=None,
         pg_data=None,
@@ -142,7 +142,6 @@ def get_discover(http_context, app, sessions):
             pginfo = PgInfo(conn)
             discover.update(
                 pg_block_size=int(pginfo.setting('block_size')),
-                pg_port=pginfo.setting('port'),
                 pg_version=pginfo.version()['full'],
                 pg_version_summary=pginfo.version()['summary'],
                 pg_data=pginfo.setting('data_directory')

--- a/temboardagent/cli.py
+++ b/temboardagent/cli.py
@@ -65,5 +65,14 @@ class Application(BaseApplication):
                 yield spec
 
     def apply_config(self):
-        self.postgres = Postgres(**self.config.postgresql)
+        self.postgres = Postgres(app=self, **self.config.postgresql)
         return super(Application, self).apply_config()
+
+    def check_compatibility(self, pg_version):
+        # check for compatibility with plugins
+        for name, plugin in self.plugins.items():
+            if pg_version < plugin.PG_MIN_VERSION[0]:
+                logger.error(
+                    "%s plugin is incompatible with Postgres below %s",
+                    name, plugin.PG_MIN_VERSION[1],
+                )

--- a/temboardagent/plugins/activity/__init__.py
+++ b/temboardagent/plugins/activity/__init__.py
@@ -1,4 +1,3 @@
-from temboardagent.errors import UserError
 from temboardagent.routing import RouteSet
 
 from . import functions as activity_functions
@@ -33,18 +32,12 @@ def post_activity_kill(http_context, app):
 
 
 class ActivityPlugin(object):
-    PG_MIN_VERSION = 90400
+    PG_MIN_VERSION = (90400, 9.4)
 
     def __init__(self, app, **kw):
         self.app = app
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.4" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
 
     def unload(self):

--- a/temboardagent/plugins/administration/__init__.py
+++ b/temboardagent/plugins/administration/__init__.py
@@ -3,7 +3,6 @@ import time
 
 from temboardagent.routing import RouteSet
 from temboardagent.tools import validate_parameters
-from temboardagent.errors import UserError
 from temboardagent.spc import error
 from temboardagent.command import (
     oneline_cmd_to_array,
@@ -91,7 +90,7 @@ def post_pg_control(http_context, app):
 
 
 class AdministrationPlugin(object):
-    PG_MIN_VERSION = 90400
+    PG_MIN_VERSION = (90400, 9.4)
     options_specs = [
         OptionSpec('administration', 'pg_ctl', default=None, validator=quoted),
     ]
@@ -101,12 +100,6 @@ class AdministrationPlugin(object):
         self.app.config.add_specs(self.options_specs)
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.4" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
 
     def unload(self):

--- a/temboardagent/plugins/dashboard/__init__.py
+++ b/temboardagent/plugins/dashboard/__init__.py
@@ -4,7 +4,6 @@ import time
 from temboardagent.toolkit import taskmanager
 from temboardagent.toolkit.configuration import OptionSpec
 from temboardagent.routing import RouteSet
-from temboardagent.errors import UserError
 
 from . import db
 from . import metrics
@@ -131,7 +130,7 @@ def dashboard_collector_worker(app):
 
 
 class DashboardPlugin(object):
-    PG_MIN_VERSION = 90400
+    PG_MIN_VERSION = (90400, 9.4)
     s = 'dashboard'
     option_specs = [
         OptionSpec(s, 'scheduler_interval', default=2, validator=int),
@@ -147,12 +146,6 @@ class DashboardPlugin(object):
         db.bootstrap(self.app.config.temboard.home, 'dashboard.db')
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.4" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
         self.app.worker_pool.add(workers)
         workers.schedule(

--- a/temboardagent/plugins/maintenance/__init__.py
+++ b/temboardagent/plugins/maintenance/__init__.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from temboardagent.errors import UserError
 from temboardagent.routing import RouteSet
 from temboardagent.toolkit import taskmanager
 from temboardagent.tools import validate_parameters
@@ -297,18 +296,12 @@ def reindex_worker(app, dbname, schema=None, table=None, index=None):
 
 
 class MaintenancePlugin(object):
-    PG_MIN_VERSION = 90400
+    PG_MIN_VERSION = (90400, 9.4)
 
     def __init__(self, app, **kw):
         self.app = app
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.4" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
         self.app.worker_pool.add(workers)
         for route in routes:

--- a/temboardagent/plugins/monitoring/__init__.py
+++ b/temboardagent/plugins/monitoring/__init__.py
@@ -10,7 +10,7 @@ from temboardagent.toolkit.validators import commalist
 from temboardagent.tools import now, validate_parameters
 from temboardagent.inventory import SysInfo
 from temboardagent import __version__ as __VERSION__
-from temboardagent.errors import UserError, HTTPError as TemboardHTTPError
+from temboardagent.errors import HTTPError as TemboardHTTPError
 
 from . import db
 from .inventory import host_info, instance_info
@@ -274,7 +274,7 @@ def monitoring_collector_worker(app):
 
 
 class MonitoringPlugin(object):
-    PG_MIN_VERSION = 90400
+    PG_MIN_VERSION = (90400, 9.4)
     s = 'monitoring'
     option_specs = [
         OptionSpec(s, 'dbnames', default='*', validator=commalist),
@@ -291,12 +291,6 @@ class MonitoringPlugin(object):
         db.bootstrap(self.app.config.temboard.home, 'monitoring.db')
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.4" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
         self.app.worker_pool.add(workers)
         workers.schedule(

--- a/temboardagent/plugins/pgconf/__init__.py
+++ b/temboardagent/plugins/pgconf/__init__.py
@@ -1,4 +1,3 @@
-from temboardagent.errors import UserError
 from temboardagent.routing import RouteSet
 
 from . import functions as pgconf_functions
@@ -36,18 +35,12 @@ def get_pg_conf_status(http_context, app):
 
 
 class PgConfPlugin(object):
-    PG_MIN_VERSION = 90500
+    PG_MIN_VERSION = (90500, 9.5)
 
     def __init__(self, app, **kw):
         self.app = app
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.5" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
 
     def unload(self):

--- a/temboardagent/plugins/statements/__init__.py
+++ b/temboardagent/plugins/statements/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from temboardagent.errors import HTTPError, UserError
+from temboardagent.errors import HTTPError
 from temboardagent.routing import RouteSet
 from temboardagent.postgres import Postgres
 from temboardagent.tools import now
@@ -76,7 +76,7 @@ def get_statements(http_context, app):
 
 
 class StatementsPlugin(object):
-    PG_MIN_VERSION = 90500
+    PG_MIN_VERSION = (90500, 9.5)
     s = "statements"
     option_specs = [OptionSpec(s, "dbname", default="postgres")]
     del s
@@ -86,12 +86,6 @@ class StatementsPlugin(object):
         self.app.config.add_specs(self.option_specs)
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.PG_MIN_VERSION:
-            msg = "%s is incompatible with Postgres below 9.5" % (
-                self.__class__.__name__)
-            raise UserError(msg)
-
         self.app.router.add(routes)
 
     def unload(self):

--- a/tests/temboard-agent-sample-plugins/temboard_agent_sample_plugins.py
+++ b/tests/temboard-agent-sample-plugins/temboard_agent_sample_plugins.py
@@ -209,7 +209,7 @@ def get_hello_from_worker(http_context, app):
 
 
 class Hello(object):
-    pg_min_version = 90400
+    pg_min_version = (90400, 9.4)
     my_options_specs = [
         OptionSpec('hello', 'name', default='World'),
         OptionSpec(
@@ -221,10 +221,6 @@ class Hello(object):
         self.app.config.add_specs(self.my_options_specs)
 
     def load(self):
-        pg_version = self.app.postgres.fetch_version()
-        if pg_version < self.pg_min_version:
-            raise UserError("hellong is incompatible with Postgres below 9.4")
-
         self.app.router.add(routes)
         self.app.worker_pool.add(workers)
         self.app.scheduler.add(workers)


### PR DESCRIPTION
Agent will not fail starting if postgres isn't available yet
Compatibility with postgres version is checked for each plugin everytime
a connection is made. This should not be too expensive.
If an incompatibility is found, an error is logged but the agent continues to work.