### PR TITLE
Fix btree bloat estimation query

### DIFF
--- a/temboardagent/plugins/maintenance/functions.py
+++ b/temboardagent/plugins/maintenance/functions.py
@@ -161,7 +161,7 @@ FROM (
       ) AS rows_data_stats
   ) AS rows_hdr_pdg_stats
 ) AS relation_stats
-ORDER BY nspname, tblname, idxname;
+ORDER BY nspname, tblname, idxname
 """  # noqa
 
 


### PR DESCRIPTION
Fixes:

    ERROR: syntax error at or near ";"
    ERROR: LINE 220: ORDER BY nspname, tblname, idxname;
    ERROR:                                             ^
    ERROR: Traceback (most recent call last):
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/httpd.py", line 132, in response
    ERROR:     (code, message) = self.route_request()
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/httpd.py", line 286, in route_request
    ERROR:     return (200, func(http_context, self.app))
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/plugins/maintenance/__init__.py", line 29, in get_instance
    ERROR:     database.update(**functions.get_database(conn))
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/plugins/maintenance/functions.py", line 326, in get_database
    ERROR:     FROM (%s) a""" % SCHEMAS_SQL)
    ERROR:   File "/usr/local/src/temboard-agent/temboardagent/postgres.py", line 46, in queryone
    ERROR:     cur.execute(dedent(query), vars)
    ERROR:   File "/usr/local/lib/python2.7/site-packages/psycopg2/extras.py", line 248, in execute
    ERROR:     return super(RealDictCursor, self).execute(query, vars)
    ERROR: SyntaxError: syntax error at or near ";"
    ERROR: LINE 220: ORDER BY nspname, tblname, idxname;
    ERROR:                                             ^
    ERROR: Internal error