### PR TITLE
Update toolkit submodule

### DIFF
--- a/temboardagent/httpd.py
+++ b/temboardagent/httpd.py
@@ -23,7 +23,7 @@ from .sharedmemory import Sessions
 from .api import check_sessionid
 from .errors import UserError
 from .toolkit.services import Service
-from .toolkit.utils import PY2
+from .toolkit.pycompat import PY2
 
 
 logger = logging.getLogger(__name__)

--- a/temboardagent/postgres.py
+++ b/temboardagent/postgres.py
@@ -11,7 +11,7 @@ from psycopg2.extensions import connection
 from psycopg2.extras import RealDictCursor
 
 from .errors import UserError
-from .toolkit.utils import PY2
+from .toolkit.pycompat import PY2
 
 
 # See https://www.psycopg.org/docs/faq.html#faq-float


### PR DESCRIPTION
We need to update imports from toolkit.utils to toolkit.pycompat accordingly.

(Extracted from #465.)