### PR TITLE
python3 support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.6-slim
 
 RUN apt-get update -y \
     && mkdir -p /usr/share/man/man1 /usr/share/man/man7 \

--- a/temboardagent/inventory.py
+++ b/temboardagent/inventory.py
@@ -2,6 +2,7 @@ import platform
 import socket
 import os
 import re
+import sys
 
 from temboardagent.tools import check_fqdn, which, to_bytes
 from temboardagent.command import exec_command
@@ -84,6 +85,10 @@ class SysInfo(Inventory):
 
     def linux_distribution(self):
         if self.os == 'Linux':
+            # Fail safely for python3.8 and above
+            # platform.linux_distribution is not available
+            if sys.version_info >= (3, 8):
+                return 'Distrib. info N/A'
             return " ".join(platform.linux_distribution()).strip()
         else:
             raise Exception("Unsupported OS.")


### PR DESCRIPTION
With this PR, we use python3.8 in dev environnement (docker image) and make sure dashboard plugin can work with this version.