### PR TITLE
Set read permission on SSL key file in RPM package

### DIFF
--- a/packaging/rpm/temboard-agent.spec
+++ b/packaging/rpm/temboard-agent.spec
@@ -75,6 +75,7 @@ PATH=$PATH:%{buildroot}%{python_sitelib}/%{pkgname}
 %post
 # auto-signed SSL cert. building
 openssl req -new -x509 -days 365 -nodes -out /etc/pki/tls/certs/temboard-agent.pem -keyout /etc/pki/tls/private/temboard-agent.key -subj "/C=XX/ST= /L=Default/O=Default/OU= /CN= " >> /dev/null 2>&1
+chmod 644 /etc/pki/tls/private/temboard-agent.key
 
 
 if [ -x /usr/share/temboard-agent/restart-all.sh ] ; then


### PR DESCRIPTION
On CentOS 8, the openssl command produces a key file with 600 permission which
makes it unreadable by 'postgres' user and thus makes the systemd service file
fail to start the agent.

```console
$ sudo systemctl status temboard-agent-12-re7.service
● temboard-agent-12-re7.service - temBoard agent for PostgreSQL
   Loaded: loaded (/etc/systemd/system/temboard-agent-12-re7.service; enabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Fri 2020-10-02 08:21:47 EDT; 7s ago
  Process: 16704 ExecStart=/usr/bin/temboard-agent -c /etc/temboard-agent/temboard-agent-12-re7.conf -p /var/run/temboard/temboard-agent->
 Main PID: 16707 (code=exited, status=1/FAILURE)

Oct 02 08:21:47 socle-centos8 temboardagent[16709]: [services] INFO: Starting <temboardagent.toolkit.taskmanager.SchedulerService object >
Oct 02 08:21:47 socle-centos8 temboardagent[16709]: [services] DEBUG: Entering <temboardagent.toolkit.taskmanager.SchedulerService object>
Oct 02 08:21:47 socle-centos8 temboardagent[16707]: [httpd] DEBUG: Using SSL key /etc/pki/tls/private/temboard-agent.key.
Oct 02 08:21:47 socle-centos8 temboardagent[16707]: [httpd] DEBUG: Using SSL certificate /etc/pki/tls/certs/temboard-agent.pem.
Oct 02 08:21:47 socle-centos8 temboardagent[16708]: [services] INFO: <temboardagent.toolkit.taskmanager.WorkerPoolService object at 0x7fc>
Oct 02 08:21:47 socle-centos8 temboardagent[16707]: [services] DEBUG: Waiting background services.
Oct 02 08:21:47 socle-centos8 temboardagent[16709]: [services] INFO: <temboardagent.toolkit.taskmanager.SchedulerService object at 0x7fca>
Oct 02 08:21:47 socle-centos8 temboardagent[16707]: [app] CRITICAL: Failed to setup SSL: [Errno 13] Permission denied.
Oct 02 08:21:47 socle-centos8 systemd[1]: temboard-agent-12-re7.service: Main process exited, code=exited, status=1/FAILURE
Oct 02 08:21:47 socle-centos8 systemd[1]: temboard-agent-12-re7.service: Failed with result 'exit-code'.

```