### PR TITLE
add psycopg2 as a proper dependency in Debian packaging

### DIFF
--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -1,4 +1,4 @@
-all: stretch jessie wheezy
+all: buster stretch jessie wheezy
 
 buster stretch jessie wheezy:
 	mkdir -p ../../dist/

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -40,7 +40,7 @@ pythonv=$($python --version |& grep -Po 'Python \K([23]\..)')
 
 #       I N S T A L L
 
-pip$pythonv install --pre --root $DESTDIR --prefix /usr --no-deps temboard-agent==$pep440v psycopg2-binary
+pip$pythonv install --pre --root $DESTDIR --prefix /usr --no-deps temboard-agent==$pep440v
 # Fake --install-layout=deb, when using wheel.
 mv $DESTDIR/usr/lib/python${pythonv}/{site,dist}-packages/
 
@@ -68,6 +68,7 @@ fpm --verbose \
     --url http://temboard.io/ \
     --depends python-pkg-resources \
     --depends ssl-cert \
+    --depends python-psycopg2 \
     --depends python${pythonv} \
     --after-install ../../share/restart-all.sh \
     "${fpm_args[@]}" \

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -79,7 +79,8 @@ fpm --verbose \
 deb=$(ls temboard-agent_*-${release}_all.deb)
 dpkg-deb -I $deb
 dpkg-deb -c $deb
-dpkg -i --ignore-depends=python-pkg-resources --ignore-depends=ssl-cert $deb
+apt-get update --quiet
+apt-get install --yes ./$deb
 (
 	cd /
 	temboard-agent --version


### PR DESCRIPTION
The real fix is in the last commit, which closes #477. Previous ones slightly improves the packaging code.