### PR TITLE
Use str() for Exception instead of 'message' attribute for python3 compat

### DIFF
--- a/temboardagent/plugins/pgconf/functions.py
+++ b/temboardagent/plugins/pgconf/functions.py
@@ -328,7 +328,7 @@ def post_settings(conn, config, http_context):
             try:
                 conn.execute(query)
             except Exception as e:
-                raise HTTPError(408, "%s: %s" % (setting['name'], e.message))
+                raise HTTPError(408, "%s: %s" % (setting['name'], e))
             ret['settings'].append({
                 'name': item['name'],
                 'setting': setting['setting'],

--- a/temboardagent/postgres.py
+++ b/temboardagent/postgres.py
@@ -70,7 +70,7 @@ class ConnectionManager(object):
             if self.app is not None:
                 self.app.check_compatibility(self.conn.server_version)
         except Exception as e:
-            raise UserError("Failed to connect to Postgres: %s" % e.message)
+            raise UserError("Failed to connect to Postgres: %s" % e)
         return self.conn
 
     def __exit__(self, *a):


### PR DESCRIPTION
Most Exception objects have no 'message' attribute in Python 3.

This resolves this kind of errors in logs:

    [taskmanager] ERROR:     data = metrics.get_metrics(app)
    [taskmanager] ERROR:   File "/usr/lib/python3.6/site-packages/temboardagent/plugins/dashboard/metrics.py", line 16, in get_metrics
    [taskmanager] ERROR:     with app.postgres.connect() as conn:
    [taskmanager] ERROR:   File "/usr/lib/python3.6/site-packages/temboardagent/postgres.py", line 73, in __enter__
    [taskmanager] ERROR:     raise UserError("Failed to connect to Postgres: %s" % e.message)
    [taskmanager] ERROR: AttributeError: 'OperationalError' object has no attribute 'message'