### PR TITLE
Build RPM with Python 3 on CentOS 7 (for master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ workflows:
     - func:
         name: stage1-func-pg<< matrix.pgversion >>-centos7
         dist: centos7
-        requires: [stage0-pkg-centos7, "stage0-unit-python:2.7"]
+        requires: [stage0-pkg-centos7, "stage0-unit-python:3.6"]
+        python: "python3"
         matrix:
           parameters:
             pgversion: ["9.6", "12"]

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -60,16 +60,10 @@ chmod a+rw dist/rpm/noarch/*
 ln -fs $(basename $rpm) dist/rpm/noarch/last_build.rpm
 
 # Test it
-if [ "${DIST}" = ".el7" ] ; then
-	PY=python2
-else
-	PY=python3
-fi
-
 sudo yum install -y $rpm
 rpm -q --list --changelog temboard-agent-${VERSION}
 (
 	cd /
 	temboard-agent --version
-	${PY} -c 'import temboardagent.toolkit'
+	python3 -c 'import temboardagent.toolkit'
 )

--- a/packaging/rpm/temboard-agent.spec
+++ b/packaging/rpm/temboard-agent.spec
@@ -2,12 +2,6 @@
 %{!?pkgversion: %global pkgversion 1.1}
 %{!?pkgrevision: %global pkgrevision 1}
 
-%{!?python_sitelib: %global python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print (get_python_lib())")}
-
-%if 0%{?rhel} >= 8
-  %global __python /usr/bin/python3
-%endif
-
 Name:          %{pkgname}
 Version:       %{pkgversion}
 Release:       %{pkgrevision}%{?dist}
@@ -22,15 +16,10 @@ Source2:       temboard-agent.service
 Source3:       temboard-agent.rpm.conf
 BuildArch:     noarch
 Requires:      openssl
-%if 0%{?rhel} < 8
-Requires:      python-setuptools
-Requires:      python-psycopg2
-BuildRequires: python-setuptools
-%else
 Requires:      python3-setuptools
 Requires:      python3-psycopg2
+BuildRequires: python3-rpm-macros
 BuildRequires: python3-setuptools
-%endif
 
 %description
 Administration & monitoring PostgreSQL agent.
@@ -41,7 +30,7 @@ Administration & monitoring PostgreSQL agent.
 
 
 %build
-%{__python} setup.py build
+%{__python3} setup.py build
 
 %pre
 # This comes from the PGDG rpm for PostgreSQL server. We want temboard to run
@@ -52,7 +41,7 @@ useradd -M -n -g postgres -o -r -d /var/lib/pgsql -s /bin/bash \
 
 
 %install
-%{__python} setup.py install --root=%{buildroot}
+%{__python3} setup.py install --root=%{buildroot}
 # config file
 %{__install} -d -m 755 %{buildroot}/%{_sysconfdir}
 %{__install} -d -m 750 %{buildroot}/%{_sysconfdir}/temboard-agent
@@ -88,7 +77,7 @@ fi
 
 %files
 %config(noreplace) %attr(-,postgres,postgres) %{_sysconfdir}/temboard-agent
-%{python_sitelib}/*
+%{python3_sitelib}/*
 /usr/share/temboard-agent/*
 /usr/bin/temboard-agent*
 
@@ -113,6 +102,9 @@ fi
 
 
 %changelog
+* Fri Oct  9 2020 Denis Laxalde <denis.laxalde@dalibo.com> - 7.1-2
+- Build with Python 3 on CentOS/RHEL 7
+
 * Fri Sep 25 2020 Pierre Giraud <pierre.giraud@dalibo.com>
 - Remove centos6 support
 


### PR DESCRIPTION
This is a cherry-pick of 21d4e9edb44f52e2c552db3e31ac4878353404ad (now in v7 branch) upon which
the pkgrevision value of temboard-agent.spec got reset to '1' because we're on
the master branch, in preparation for version 8.0.