### PR TITLE
Fix order of arguments in log message of SqlProbe

### DIFF
--- a/temboardagent/plugins/monitoring/probes.py
+++ b/temboardagent/plugins/monitoring/probes.py
@@ -371,7 +371,7 @@ class SqlProbe(Probe):
         except Exception as e:
             logger.error(
                 "Unable to run probe \"%s\" on \"%s\" on database \"%s\": %s",
-                e, self.get_name(), conninfo['instance'], database)
+                self.get_name(), conninfo['instance'], database, e)
         return output
 
     def run(self, conninfo):


### PR DESCRIPTION
This should make the error message understandable, e.g. in #484.