### PR TITLE
Include exception info in error log when SqlProbe fails to run

### DIFF
--- a/temboardagent/plugins/monitoring/probes.py
+++ b/temboardagent/plugins/monitoring/probes.py
@@ -371,7 +371,9 @@ class SqlProbe(Probe):
         except Exception as e:
             logger.error(
                 "Unable to run probe \"%s\" on \"%s\" on database \"%s\": %s",
-                self.get_name(), conninfo['instance'], database, e)
+                self.get_name(), conninfo['instance'], database, e,
+                exc_info=True,
+            )
         return output
 
     def run(self, conninfo):


### PR DESCRIPTION
Attempt to debug issue #484.