### PR TITLE
Restore RPM pkgrevision to 1

### DIFF
--- a/packaging/rpm/temboard-agent.spec
+++ b/packaging/rpm/temboard-agent.spec
@@ -1,6 +1,6 @@
 %global pkgname temboard-agent
 %{!?pkgversion: %global pkgversion 1.1}
-%{!?pkgrevision: %global pkgrevision 2}
+%{!?pkgrevision: %global pkgrevision 1}
 
 Name:          %{pkgname}
 Version:       %{pkgversion}


### PR DESCRIPTION
RPM package 7.1-2 got shipped to yum.dalibo.org/labs. Before the next 7.x
release, we need to restore the RPM package revision number to its previous
value. Follow-up on 21d4e9edb44f52e2c552db3e31ac4878353404ad.