### PR TITLE
Put packages in python3/dist-packages directory

### DIFF
--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -47,7 +47,8 @@ else
 fi
 # Fake --install-layout=deb, when using wheel.
 pythonv=$(python3 --version |& grep -Po 'Python \K([3]\..)')
-mv $DESTDIR/usr/lib/python${pythonv}/{site,dist}-packages/
+mkdir -p ${DESTDIR}/usr/lib/python3/dist-packages/
+mv $DESTDIR/usr/lib/python${pythonv}/site-packages/* $DESTDIR/usr/lib/python3/dist-packages/
 
 #       B U I L D
 


### PR DESCRIPTION
This change will make sure that temboardagent package is installed in `python3/dist-packages` instead of `python3.x/dist-packages`.
This fixes issues with temboard not working on versions of unbuntu on which the version of python may not be 3.7.