### PR TITLE
Do not include .pyc files in Debian package

### DIFF
--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -40,10 +40,10 @@ release=0dlb1${codename}1
 if [ "${FROMSOURCE-}" = 1 ] ;
 then
 	# Install from sources
-	pip3 install --pre --root $DESTDIR --prefix /usr --no-deps $TOP_SRCDIR
+	pip3 install --pre --root $DESTDIR --prefix /usr --no-deps --no-compile $TOP_SRCDIR
 else
 	# Install from pypi
-	pip3 install --pre --root $DESTDIR --prefix /usr --no-deps temboard-agent==$pep440v
+	pip3 install --pre --root $DESTDIR --prefix /usr --no-deps --no-compile temboard-agent==$pep440v
 fi
 # Fake --install-layout=deb, when using wheel.
 pythonv=$(python3 --version |& grep -Po 'Python \K([3]\..)')


### PR DESCRIPTION
Previously, as evidenced by the output of 'dpkg-deb -c' command in mkdeb.sh,
the .deb package contained .pyc files specific to the python version used at
build time (e.g.
./usr/lib/python3/dist-packages/temboardagent/__pycache__/routing.cpython-37.pyc).
This is problematic when then installing the package on a different python
version.

By calling pip install with --no-compile, we should hopefully avoid that.