### PR TITLE
Use default value for used port if none found

### DIFF
--- a/share/auto_configure.sh
+++ b/share/auto_configure.sh
@@ -51,7 +51,7 @@ find_next_free_port() {
 	mapfile -t used_a < <(ss -ln4t '( sport >= 2345 and sport <= 3000 )' | grep -Po ':\K\d+')
 	# To mock ss output, use seq:
 	# mapfile -t used_a < <(seq 2345 3000)
-	used="${used_a[*]}"
+	used="${used_a[*]:-}"
 	for port in {2345..3000} ; do
 		if [[ " $used " =~ \ $port\  ]] ; then continue ; fi
 		echo $port;


### PR DESCRIPTION
Fixes #507

Prevents bash from catching an error because of '-u' set for error handling
Note : an 'unbound variable' error is caught on some version of bash
bash 4.2 on debian wheezy but not on bash 4.3 on debian jessie or up
On centOS, the error is raised whatever the version of bash is.

FIXME: there could be other solutions like using  when declaring the variable