### PR TITLE
Decode content before JSON loading in register

### DIFF
--- a/temboardagent/scripts/register.py
+++ b/temboardagent/scripts/register.py
@@ -119,7 +119,7 @@ def wrapped_main(args, app):
                 "Content-type": "application/json"
             }
         )
-        infos = json.loads(content)
+        infos = json.loads(content.decode("utf-8"))
 
         print("Login at %s ..." % (args.ui_address))
         username = ask_username()


### PR DESCRIPTION
Since Python 3.6, json.loads() will try to decode a bytes content. For older
Python 3 version (e.g. 3.5 as available in Debian/stretch), this will fail with
a "the JSON object must be str, not bytes" TypeError. See commit
https://github.com/python/cpython/commit/b161562f72a28e83e62ec0a0a5de601e7724629f
in CPython.

To prevent this error, and hopefully make agent registration work on python
3.5, we decode the content of HTTP response ourselves.

Fixes #510.