### PR TITLE
Convert 'query' field from pg_stat_statements as a bytea

### DIFF
--- a/temboardagent/plugins/statements/__init__.py
+++ b/temboardagent/plugins/statements/__init__.py
@@ -15,6 +15,9 @@ query = """\
 SELECT
   rolname,
   datname,
+  convert_from(
+    pgss.query::bytea, pg_catalog.pg_encoding_to_char(pg_database.encoding)
+  ) as query,
   pgss.*
 FROM pg_stat_statements pgss
 JOIN pg_authid ON pgss.userid = pg_authid.oid


### PR DESCRIPTION
When the postgres instance contain different encodings, we cannot use a single
encoding to decode value in psycopg2, thus leading to decode errors such as the
one reported in issue #513. We fix this by converting the query field from
pg_stat_statements view (the only one of 'text' type) to a bytea.

(Note: it's hard to test this using our func tests suite especially because we're still using the "spc" driver there; so it'd be nice if someone could test this on a real setup, cc @pgiraud.)