### PR TITLE
Fix start-stop-daemon insecure error

### DIFF
--- a/packaging/deb/temboard-agent.init
+++ b/packaging/deb/temboard-agent.init
@@ -33,7 +33,7 @@ test -f $CONF || exit 0
 
 . /lib/lsb/init-functions
 
-SSD="start-stop-daemon --pidfile $PIDFILE --quiet"
+SSD="start-stop-daemon --pidfile $PIDFILE --quiet --user $RUNASUSER"
 
 case "$1" in
   start)


### PR DESCRIPTION
When the service is restarted with 'service temboard-agent restart', one can
see the following message:

    start-stop-daemon: matching only on non-root pidfile /var/run/postgresql/temboard-agent.pid is insecure

We is a similar fix as
https://salsa.debian.org/debian/amavisd-new/-/commit/31cf737fd4d2c067ded79ffb812f04ce9393e185,
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921016

Note: this is untested.