### PR TITLE
Ensure that the result of hostname -f is decoded in python 3

### DIFF
--- a/temboardagent/inventory.py
+++ b/temboardagent/inventory.py
@@ -103,7 +103,7 @@ class SysInfo(Inventory):
             # Try to get hostname (FQDN) using 'hostname -f'
             (rc, out, err) = exec_command([which('hostname'), '-f'])
             if rc == 0:
-                hostname = out.encode('utf-8').strip()
+                hostname = out.decode('utf-8').strip()
         except Exception:
             try:
                 # Try to get hostname (FQDN) using socket module


### PR DESCRIPTION
The hostname detection code does not properly transform a byte string
to utf-8 with python 3 resulting in a failure do process the result of
execution of hostname -f.