### PR TITLE
Fix parsing of primary_conninfo

### DIFF
--- a/temboardagent/plugins/monitoring/probes.py
+++ b/temboardagent/plugins/monitoring/probes.py
@@ -85,7 +85,7 @@ def parse_primary_conninfo(pci):
     if m:
         for f in re.findall(r"(\w+)\s*=\s*''(.+?)''", m.group(1)):
             r[f[0]] = f[1]
-        for f in re.findall(r"(\w+)\s*=\s*(\w+)", m.group(1)):
+        for f in re.findall(r"(\w+)\s*=\s*([\w\.-]+)", m.group(1)):
             r[f[0]] = f[1]
     return (r.get('host'), r.get('port'), r.get('user'), r.get('password'))
 


### PR DESCRIPTION
In the replication_lag monitoring probe, the regex extracting values of non
quoted keyword=value parameters from primary_conninfo does not allow dot
and hypens, so it extract parts of ip addresses and fqdn, resulting in a
failed connection.