### PR TITLE
Unquote string when extracting primary_conninfo in probes

### DIFF
--- a/temboardagent/plugins/monitoring/probes.py
+++ b/temboardagent/plugins/monitoring/probes.py
@@ -87,7 +87,13 @@ def parse_primary_conninfo(pci):
     m = re.match(r'.*primary_conninfo\s*=\s*\'(.*)\'[^\']*$', pci)
     if not m:
         raise Exception("Unable to parse primary_conninfo.")
-    return m.group(1)
+
+    # Unquote string. When coming from recovery.conf, single quotes can be
+    # doubled or escaped with a backslash
+    c = m.group(1).replace("''", "'")
+    c = c.replace("\\'", "'")
+
+    return c
 
 
 def get_primary_conninfo(conn):


### PR DESCRIPTION
When extracting the value of primary conninfo, some content can be
enclosing by single quotes. They must be quoted in recovery.conf with
backslashes or have signled doubled. Those backlashes must be removed
before using the connection string with psycopg2 (or libpq).

Closes #531 