### PR TITLE
Require distutils

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,6 +1,6 @@
 # Same pinning as RTD. Picked from build logs.
 # See also: https://github.com/rtfd/readthedocs.org/blob/61165bae4b55dc985041390a29e4ee95432ec3dd/readthedocs/doc_builder/python_environments.py#L247-L251
 sphinx<1.8
-docutils
+docutils<0.18
 sphinxcontrib-httpdomain
 sphinx_rtd_theme

--- a/packaging/deb/Makefile
+++ b/packaging/deb/Makefile
@@ -6,8 +6,8 @@ buster stretch jessie wheezy:
 	$(MAKE) changes-$@
 
 changes-%:
-	./mkchanges.sh $(shell readlink -e ../../dist/last_build.deb) $*
+	./mkchanges.sh $(shell readlink -e ../../dist/temboard-agent_last.deb) $*
 
 push:
-	version=$$(dpkg-deb -f ../../dist/last_build.deb  Version | grep -Po '.*(?=-0dlb.*)'); \
+	version=$$(dpkg-deb -f ../../dist/temboard-agent_last.deb  Version | grep -Po '.*(?=-0dlb.*)'); \
 	find ../../dist/ -name "temboard-agent_$${version}-0dlb*.changes" | xargs -rt dput labs

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -99,5 +99,5 @@ apt-get install --yes ./$deb
 mkdir -p ${DISTDIR}/
 mv -fv $deb ${DISTDIR}/
 # Point deb as latest build for changes generation.
-ln -fs $(basename $deb) ${DISTDIR}/last_build.deb
+ln -fs "$(basename "$deb")" "${DISTDIR}/temboard-agent_last.deb"
 chown -R ${UID_GID} ${DISTDIR}/

--- a/packaging/deb/mkdeb.sh
+++ b/packaging/deb/mkdeb.sh
@@ -57,6 +57,14 @@ if ! [ -f /usr/bin/systemctl ] ; then
 	fpm_args+=(--deb-init temboard-agent.init)
 fi
 
+case "$codename" in
+	jessie|stretch|wheezy)
+	;;
+	*)
+		fpm_args+=(--depends python3-distutils)
+	;;
+esac
+
 fpm --verbose \
     --force \
     --debug-workspace \


### PR DESCRIPTION
Fixes:

    $ temboard-agent --version
    Traceback (most recent call last):
    File "/usr/bin/temboard-agent", line 5, in <module>
        from temboardagent.scripts.agent import main
    File "/usr/lib/python3/dist-packages/temboardagent/scripts/agent.py", line 12, in <module>
        from ..cli import Application
    File "/usr/lib/python3/dist-packages/temboardagent/cli.py", line 6, in <module>
        from .toolkit.app import BaseApplication
    File "/usr/lib/python3/dist-packages/temboardagent/toolkit/app.py", line 5, in <module>
        from distutils.util import strtobool
    ModuleNotFoundError: No module named 'distutils.util'