### PR TITLE
Return None scalar if result set is empty

### DIFF
--- a/temboardagent/postgres.py
+++ b/temboardagent/postgres.py
@@ -47,7 +47,11 @@ class ConnectionHelper(connection):
             return cur.fetchone()
 
     def query_scalar(self, query, vars=None):
-        return next(iter(self.queryone(query, vars).values()))
+        row = self.queryone(query, vars)
+        if row is None:
+            return
+        else:
+            return next(iter(row.values()))
 
 
 class ConnectionManager(object):


### PR DESCRIPTION
Fixes:

    <class 'AttributeError'>: 'NoneType' object has no attribute 'values'
    Traceback (most recent call last):
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/toolkit/taskmanager.py", line 882, in exec_worker
        res = getattr(sys.modules[module], function)(*args, **kws)
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/toolkit/taskmanager.py", line 1046, in wrapper
        return function(app=self.app, *a, **kw)
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/plugins/dashboard/__init__.py", line 115, in dashboard_collector_worker
        data = metrics.get_metrics(app)
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/plugins/dashboard/metrics.py", line 27, in get_metrics
        pg_data=pginfo.setting('data_directory'),
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/inventory.py", line 301, in setting
        (name,)
      File "/pgdata/.venv/lib64/python3.6/site-packages/temboardagent/postgres.py", line 50, in query_scalar
        return next(iter(self.queryone(query, vars).values()))
    AttributeError: 'NoneType' object has no attribute 'values'`